### PR TITLE
fixed issue with move and resize event on X11

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -3126,19 +3126,19 @@ RGFW_UNUSED(win); /* if buffer rendering is not being used */
 			win->event.type = RGFW_focusOut;
 			break;
 		case ConfigureNotify: {
-      // detect resize
-      if (E.xconfigure.width != win->r.w || E.xconfigure.height != win->r.h) {
+			// detect resize
+      			if (E.xconfigure.width != win->r.w || E.xconfigure.height != win->r.h) {
 				win->event.type = RGFW_windowResized;
-			  win->r = RGFW_RECT(win->r.x, win->r.y, E.xconfigure.width, E.xconfigure.height);
-			  break;
-      }  
+				win->r = RGFW_RECT(win->r.x, win->r.y, E.xconfigure.width, E.xconfigure.height);
+				break;
+      			}  
       
-      // detect move
-      if (E.xconfigure.x != win->r.x || E.xconfigure.y != win->r.y) {
+      			// detect move
+      			if (E.xconfigure.x != win->r.x || E.xconfigure.y != win->r.y) {
 				win->event.type = RGFW_windowMoved;
-			  win->r = RGFW_RECT(E.xconfigure.x, E.xconfigure.y, win->r.w, win->r.h);
-			  break;
-      } 
+				win->r = RGFW_RECT(E.xconfigure.x, E.xconfigure.y, win->r.w, win->r.h);
+				break;
+			} 
 		}
 		default: {
 			break;

--- a/RGFW.h
+++ b/RGFW.h
@@ -3126,14 +3126,19 @@ RGFW_UNUSED(win); /* if buffer rendering is not being used */
 			win->event.type = RGFW_focusOut;
 			break;
 		case ConfigureNotify: {
-            if (E.xconfigure.x != win->r.x || E.xconfigure.y != win->r.y)
-				win->event.type = RGFW_windowMoved;
-            if (E.xconfigure.width != win->r.w || E.xconfigure.height != win->r.h)
+      // detect resize
+      if (E.xconfigure.width != win->r.w || E.xconfigure.height != win->r.h) {
 				win->event.type = RGFW_windowResized;
-
-			win->r = RGFW_RECT(E.xconfigure.x, E.xconfigure.y, E.xconfigure.width, E.xconfigure.height);
-						
-			break;
+			  win->r = RGFW_RECT(win->r.x, win->r.y, E.xconfigure.width, E.xconfigure.height);
+			  break;
+      }  
+      
+      // detect move
+      if (E.xconfigure.x != win->r.x || E.xconfigure.y != win->r.y) {
+				win->event.type = RGFW_windowMoved;
+			  win->r = RGFW_RECT(E.xconfigure.x, E.xconfigure.y, win->r.w, win->r.h);
+			  break;
+      } 
 		}
 		default: {
 			break;

--- a/RGFW.h
+++ b/RGFW.h
@@ -3128,7 +3128,7 @@ RGFW_UNUSED(win); /* if buffer rendering is not being used */
 		case ConfigureNotify: {
             if (E.xconfigure.x != win->r.x || E.xconfigure.y != win->r.y)
 				win->event.type = RGFW_windowMoved;
-            else if (E.xconfigure.width != win->r.w || E.xconfigure.height != win->r.h)
+            if (E.xconfigure.width != win->r.w || E.xconfigure.height != win->r.h)
 				win->event.type = RGFW_windowResized;
 
 			win->r = RGFW_RECT(E.xconfigure.x, E.xconfigure.y, E.xconfigure.width, E.xconfigure.height);


### PR DESCRIPTION
For some reason, the `E.xconfigure` and `win->r` are always different, even on resize. This causes the first if statement to always be true, so `win->event.type` was never set to `RGFW_windowResized`.

Then I found out that on resize, `E.xconfigure.x` and `E.xconfigure.y` are sometimes zero.
So setting `win->r` to the `E.xconfigure` dimensions immediately triggers another move event.
