### PR TITLE
Update RGFW.h

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -3292,7 +3292,7 @@ RGFW_UNUSED(win); /* if buffer rendering is not being used */
 					index++;
 					line++;
 				}
-
+				path[index] = '\0';
 				strcpy(win->event.droppedFiles[win->event.droppedFilesCount - 1], path);
 			}
 


### PR DESCRIPTION
On linux, when you drag and drop file and try to read the file path, sometimes the file path does not have a null terminating character - or at least it has junk after the file path. 

This fixed it for my use case, but I've only tested it in my app.