### PR TITLE
Mac OS memory fixes

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -458,13 +458,6 @@ typedef struct { i32 x, y; } RGFW_vector;
 		void* window;
 		b8 dndPassed;
 #endif
-#if defined(RGFW_MACOS) && defined(RGFW_BUFFER)
-        // When drawing directly to the buffer
-        // saving the represensation and image
-        // saves heaps of allocations
-        void* g_rep;
-        void* g_image;
-#endif
 
 #if (defined(RGFW_OPENGL)) && !defined(RGFW_OSMESA)
 #ifdef RGFW_MACOS
@@ -5890,11 +5883,6 @@ RGFW_UNUSED(win); /* if buffer rendering is not being used */
 		NSRetain(win->src.window);
 		NSRetain(NSApp);
 
-        // RR
-#ifdef RGFW_BUFFER
-        win->src.g_rep = NULL;
-        win->src.g_image = NULL;
-#endif
         RGFW_setWindowQuitCallback(RGFW_window_quitCallbackMac);
 		return win;
 	}
@@ -6655,8 +6643,6 @@ RGFW_UNUSED(win); /* if buffer rendering is not being used */
 #ifdef RGFW_BUFFER
 		//release(win->src.bitmap);
 		//release(win->src.image);
-        // NSRelease(win->src.g_image);
-        // NSRelease(win->src.g_rep);
 #endif
 
 		// CVDisplayLinkStop(win->src.displayLink);


### PR DESCRIPTION
Howdy!

I don't think you will likely want to just take this PR, but you might want to look at how I fixed some of the bits here. Some things I found while trying to implement my app that renders directly to the window (no OpenGL, etc).

* The way it was using NSImage and NSRepresentation was causing gigabyte of allocations that were not being cleaned up. If you want to check run the app for about 10 minutes with activity monitor on. This changes the swapBuffer code to make that a bit more streamlined - seems to behave better now.
* Similar situation with the NSEvents - I created some autorelease pools around the window and the checkEvents code to try to handle the memory a bit nicer. Because of the way this works (MacOS sends messages to objects like smalltalk not like calling functions) I had to make use of the close window call back to fire a custom message so it can be handled in the checkEvent loop.
*  The way data was being taken from the pasteboard was corrupting memory - the new way seems to not crash / corrupt, but uses the NSEvent system more.

Because of the redraw changes, the code for window setup is slightly different for Mac vs Linux and Windows. I can't share the code I am working on, but if you are using RAW renderer you'd need to do something like:

```c
 562      RGFW_window *win =                                                                                                                                                                
 563          RGFW_createWindow("SPIKE", RGFW_RECT(0, 0, 272, 376), RGFW_NO_RESIZE | RGFW_ALLOW_DND | RGFW_NO_GPU_RENDER); 
```

```c
643  #ifndef __APPLE__                                                                                                                                                                     
644      Context ctx = {win, RGFW_getScreenSize()};                                                                                                                      
645  #else                                                                                                                                                                                 
646      Context ctx = {win, {272, 376}};                                                                                                                                
647  #endif
```

If you wanted a window of 272, 376 because Mac will try to create a draw surface that is the size of the whole screen instead of just the small area. Anyway, that works.

Again, I don't think you should just take this PR as is, but hopefully this provides some hints around some things that might need fixing. With this PR my app now behaves nicely memory wise and can do Drag and Drop consistently without pooping the bed :D
