### PR TITLE
fix: window not at front on macos

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -7300,7 +7300,8 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 		}
 
 		// Show the window
-		((id(*)(id, SEL, SEL))objc_msgSend)(win->src.window, sel_registerName("makeKeyAndOrderFront:"), win->src.window);
+		objc_msgSend_void_bool(NSApp, sel_registerName("activateIgnoringOtherApps:"), true);
+		((id(*)(id, SEL, SEL))objc_msgSend)(win->src.window, sel_registerName("makeKeyAndOrderFront:"), NULL);
 		objc_msgSend_void_bool(win->src.window, sel_registerName("setIsVisible:"), true);
 
 		if (!RGFW_loaded) {

--- a/RGFW.h
+++ b/RGFW.h
@@ -7300,7 +7300,7 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 		}
 
 		// Show the window
-		((id(*)(id, SEL, SEL))objc_msgSend)(win->src.window, sel_registerName("makeKeyAndOrderFront:"), NULL);
+		((id(*)(id, SEL, SEL))objc_msgSend)(win->src.window, sel_registerName("makeKeyAndOrderFront:"), win->src.window);
 		objc_msgSend_void_bool(win->src.window, sel_registerName("setIsVisible:"), true);
 
 		if (!RGFW_loaded) {


### PR DESCRIPTION
Before this change examples never opened in front of currently active window so you needed to alt tab, this also seemed to break the camera demo as my mouse would just be stuck in place but with no way for me to actually get to the window using the trackpad.
After this change windows always open in front.

That said, maybe this should eventually be exposed as a parameter when creating a window: "should the window be immediately focused and brought to the foreground"

For reference I'm on macOS version 14.4.1
Here is the equivalent code https://github.com/glfw/glfw/blob/master/src/cocoa_window.m#L1238