### PR TITLE
fixed cross initialization with jump to label in cpp

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -2805,7 +2805,7 @@ Start of Linux / Unix defines
 
 		u32 i;
 		win->event.type = 0;
-
+		XEvent reply = { ClientMessage };
 
 		switch (E.type) {
 		case KeyPress:
@@ -2944,7 +2944,6 @@ Start of Linux / Unix defines
 			if ((win->_winArgs & RGFW_ALLOW_DND) == 0)
 				break;
 
-			XEvent reply = { ClientMessage };
 			reply.xclient.window = xdnd.source;
 			reply.xclient.format = 32;
 			reply.xclient.data.l[0] = (long) win->src.window;


### PR DESCRIPTION
I've encoutered an error while working with c++17 that prohibited jumping into a case label that crosses the initialization of a variable.
```make
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:3066:22: error: jump to case label
 3066 |                 case SelectionNotify: {
      |                      ^~~~~~~~~~~~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:2938:32: note:   crosses initialization of ‘XEvent reply’
 2938 |                         XEvent reply = { ClientMessage };
      |                                ^~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:3153:22: error: jump to case label
 3153 |                 case FocusIn:
      |                      ^~~~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:2938:32: note:   crosses initialization of ‘XEvent reply’
 2938 |                         XEvent reply = { ClientMessage };
      |                                ^~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:3160:22: error: jump to case label
 3160 |                 case FocusOut:
      |                      ^~~~~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:2938:32: note:   crosses initialization of ‘XEvent reply’
 2938 |                         XEvent reply = { ClientMessage };
      |                                ^~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:3166:22: error: jump to case label
 3166 |                 case EnterNotify: {
      |                      ^~~~~~~~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:2938:32: note:   crosses initialization of ‘XEvent reply’
 2938 |                         XEvent reply = { ClientMessage };
      |                                ^~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:3174:22: error: jump to case label
 3174 |                 case LeaveNotify: {
      |                      ^~~~~~~~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:2938:32: note:   crosses initialization of ‘XEvent reply’
 2938 |                         XEvent reply = { ClientMessage };
      |                                ^~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:3180:22: error: jump to case label
 3180 |                 case ConfigureNotify: {
      |                      ^~~~~~~~~~~~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:2938:32: note:   crosses initialization of ‘XEvent reply’
 2938 |                         XEvent reply = { ClientMessage };
      |                                ^~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:3199:17: error: jump to case label
 3199 |                 default: {
      |                 ^~~~~~~
/home/darekparodia/Documents/programowanie/srv-monitor/include/RGFW.h:2938:32: note:   crosses initialization of ‘XEvent reply’
 2938 |                         XEvent reply = { ClientMessage };
      |                                ^~~~~
```
after moving ```Xevent reply = { ClientMessage };``` outside switch case it compiled and worked properly. I haven't encoutered any more issues yet.