### PR TITLE
keycode rewrite

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -1449,7 +1449,6 @@ u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
 		case RGFW_OS_BASED_VALUE(84, 0x28, 0, 0, 0): return RGFW_Down;
 		case RGFW_OS_BASED_VALUE(127, 0x90, 0, 0, 0): return RGFW_Numlock;
 		case RGFW_OS_BASED_VALUE(156, 0x61, 0, 0, 0): 
-			printf("h\n");
 			return RGFW_KP_1;	
 		case RGFW_OS_BASED_VALUE(153, 0x62, 0, 0, 0): return RGFW_KP_2;
 		case RGFW_OS_BASED_VALUE(155, 0x63, 0, 0, 0): return RGFW_KP_3;

--- a/RGFW.h
+++ b/RGFW.h
@@ -1413,24 +1413,20 @@ u32 RGFW_apiPhysicalToRGFW(u32 keycode) {
 	return RGFW_keycodes[keycode];
 }
 
-#ifdef RGFW_WINDOWS
-u32 CharLowerBuffA(char*, u32);
-#endif
-
 u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
 	switch (mappedKey) {
 		#ifdef RGFW_WINDOWS
 		case 0xC0: return '`';
 		case 189: return '-';  
 		case 187: return '=';
-		case 190: return RGFW_Period;
-		case 188: return RGFW_Comma;
-		case 191: return RGFW_Slash;
-		case 219: return RGFW_Bracket;
-		case 221: return RGFW_CloseBracket; 
-		case 186: return RGFW_Semicolon;  
-		case 222: return RGFW_Apostrophe;  
-		case 322: return RGFW_BackSlash;
+		case 190: return '.';
+		case 188: return ',';
+		case 191: return '/';
+		case 219: return '[';
+		case 221: return ']'; 
+		case 186: return ';';  
+		case 222: return '\'';  
+		case 220: return '\\';
 		#else
 		case RGFW_OS_BASED_VALUE(226, 0, 0, 0, 0): return RGFW_ShiftR;
 		case RGFW_OS_BASED_VALUE(228, 0, 0, 0, 0): return RGFW_ControlR;
@@ -1490,10 +1486,6 @@ u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
 		default: break;
 	}
 
-	#ifdef RGFW_WINDOWS
-	u8 ch = mappedKey;
-	CharLowerBuffA(&ch, 1);
-	#endif
 	return mappedKey;
 }
 
@@ -6019,8 +6011,11 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 					else win->event.physicalKey = RGFW_ControlL;
 				}
 
-				win->event.mappedKey = RGFW_apiMappedToRGFW((u32)msg.wParam);
-								
+				win->event.mappedKey = RGFW_apiMappedToRGFW(msg.wParam);
+
+				if (win->event.mappedKey >= 'A' && win->event.mappedKey <= 'Z')				
+					CharLowerBuffA(&win->event.mappedKey, 1);
+				
 				RGFW_keyboard[win->event.physicalKey].prev = RGFW_isPressed(win, win->event.physicalKey);
 
 				static char keyName[16];
@@ -6067,7 +6062,11 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 					else win->event.physicalKey = RGFW_ControlL;
 				}
 
-				win->event.mappedKey = RGFW_apiMappedToRGFW((u32)msg.wParam);
+				win->event.mappedKey = RGFW_apiMappedToRGFW(msg.wParam);
+				
+				if (win->event.mappedKey >= 'A' && win->event.mappedKey <= 'Z')				
+					CharLowerBuffA(&win->event.mappedKey, 1);
+					
 				RGFW_keyboard[win->event.physicalKey].prev = RGFW_isPressed(win, win->event.physicalKey);
 
 				static char keyName[16];

--- a/RGFW.h
+++ b/RGFW.h
@@ -1414,9 +1414,6 @@ u32 RGFW_apiPhysicalToRGFW(u32 keycode) {
 }
 
 u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
-	if (mappedKey >= 'A' && mappedKey <= 'Z')				
-		mappedKey += 'a' - 'A';
-	
 #ifndef RGFW_MACOS
 	switch (mappedKey) {
 		#ifdef RGFW_WINDOWS
@@ -1489,6 +1486,10 @@ u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
 		default: break;
 	}
 #endif
+
+	if (mappedKey >= 'A' && mappedKey <= 'Z')				
+		mappedKey += 'a' - 'A';
+	
 	return mappedKey;
 }
 
@@ -6016,9 +6017,6 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 
 				win->event.mappedKey = RGFW_apiMappedToRGFW(msg.wParam);
 
-				if (win->event.mappedKey >= 'A' && win->event.mappedKey <= 'Z')				
-					CharLowerBuffA(&win->event.mappedKey, 1);
-				
 				RGFW_keyboard[win->event.physicalKey].prev = RGFW_isPressed(win, win->event.physicalKey);
 
 				static char keyName[16];
@@ -6067,9 +6065,6 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 
 				win->event.mappedKey = RGFW_apiMappedToRGFW(msg.wParam);
 				
-				if (win->event.mappedKey >= 'A' && win->event.mappedKey <= 'Z')				
-					CharLowerBuffA(&win->event.mappedKey, 1);
-					
 				RGFW_keyboard[win->event.physicalKey].prev = RGFW_isPressed(win, win->event.physicalKey);
 
 				static char keyName[16];

--- a/RGFW.h
+++ b/RGFW.h
@@ -2804,10 +2804,7 @@ Start of Linux / Unix defines
 				win->event.key = RGFW_apiKeyToRGFW(E.xkey.keycode);
 
 				KeySym sym = (KeySym)XkbKeycodeToKeysym((Display*) win->src.display, E.xkey.keycode, 0, E.xkey.state & ShiftMask ? 1 : 0);
-				if (mappedKey == XK_Insert)
-					mappedKey = RGFW_Insert;
-				else
-					win->event.keyChar = (u8)sym;
+				win->event.keyChar = (u8)sym;
 				
 				char* str = (char*)XKeysymToString(sym);
 				if (str != NULL)

--- a/RGFW.h
+++ b/RGFW.h
@@ -392,7 +392,7 @@ typedef RGFW_ENUM(u8, RGFW_event_types) {
 	RGFW_keyReleased, /*!< a key has been released*/
 	/*! key event note
 		the code of the key pressed is stored in
-		RGFW_Event.mappedKey
+		RGFW_Event.physicalKey
 		!!Keycodes defined at the bottom of the RGFW_HEADER part of this file!!
 
 		while a string version is stored in
@@ -547,8 +547,8 @@ typedef struct RGFW_Event {
 	u32 type; /*!< which event has been sent?*/
 	RGFW_point point; /*!< mouse x, y of event (or drop point) */
 	
-	u8 mappedKey; /*!< mapped key of the event  !!Keycodes defined at the bottom of the RGFW_HEADER part of this file!! */	
-	u8 physicalKey; /*!< the physical key of the event, refers to where key is physically */
+	u8 physicalKey; /*!< the physical key of the event, refers to where key is physically !!Keycodes defined at the bottom of the RGFW_HEADER part of this file!! */	
+	u8 mappedKey; /*!< mapped key of the event*/
 
 	b8 repeat; /*!< key press event repeated (the key is being held) */
 	b8 inFocus;  /*!< if the window is in focus or not (this is always true for MacOS windows due to the api being weird) */
@@ -938,7 +938,7 @@ typedef void (* RGFW_dndInitfunc)(RGFW_window* win, RGFW_point point);
 /*! RGFW_windowRefresh, the window that needs to be refreshed */
 typedef void (* RGFW_windowrefreshfunc)(RGFW_window* win);
 /*! RGFW_keyPressed / RGFW_keyReleased, the window that got the event, the mapped key, the physical key, the string version, the state of mod keys, if it was a press (else it's a release) */
-typedef void (* RGFW_keyfunc)(RGFW_window* win, u32 mappedKey, u32 physicalKey, char keyName[16], u8 lockState, b8 pressed);
+typedef void (* RGFW_keyfunc)(RGFW_window* win, u32 physicalKey, u32 mappedKey, char keyName[16], u8 lockState, b8 pressed);
 /*! RGFW_mouseButtonPressed / RGFW_mouseButtonReleased, the window that got the event, the button that was pressed, the scroll value, if it was a press (else it's a release)  */
 typedef void (* RGFW_mousebuttonfunc)(RGFW_window* win, u8 button, double scroll, b8 pressed);
 /*!gp /gp, the window that got the event, the button that was pressed, the scroll value, if it was a press (else it's a release) */
@@ -1265,121 +1265,121 @@ This is the start of keycode data
 #include <linux/input-event-codes.h>
 #endif
 
-u8 RGFW_keycodes [RGFW_OS_BASED_VALUE(136, 337, 128, DOM_VK_WIN_OEM_CLEAR + 1, 130)] = {
+u8 RGFW_keycodes [RGFW_OS_BASED_VALUE(136, 0x15C + 1, 128, DOM_VK_WIN_OEM_CLEAR + 1, 130)] = {
 #ifdef __cplusplus
 	0
 };
 void RGFW_init_keys(void) {
 #endif
-	RGFW_MAP [RGFW_OS_BASED_VALUE(49, 192, 50, DOM_VK_BACK_QUOTE, KEY_GRAVE)] = RGFW_Backtick 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(49, 0x029, 50, DOM_VK_BACK_QUOTE, KEY_GRAVE)] = RGFW_Backtick 		RGFW_NEXT
 
-	RGFW_MAP [RGFW_OS_BASED_VALUE(19, 0x30, 29, DOM_VK_0, KEY_0)] = RGFW_0 					RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(10, 0x31, 18, DOM_VK_1, KEY_1)] = RGFW_1						RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(11, 0x32, 19, DOM_VK_2, KEY_2)] = RGFW_2						RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(12, 0x33, 20, DOM_VK_3, KEY_3)] = RGFW_3						RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(13, 0x34, 21, DOM_VK_4, KEY_4)] = RGFW_4						RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(14, 0x35, 23, DOM_VK_5, KEY_5)] = RGFW_5                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(15, 0x36, 22, DOM_VK_6, KEY_6)] = RGFW_6                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(16, 0x37, 26, DOM_VK_7, KEY_7)] = RGFW_7                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(17, 0x38, 28, DOM_VK_8, KEY_8)] = RGFW_8                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(18, 0x39, 25, DOM_VK_9, KEY_9)] = RGFW_9,
+	RGFW_MAP [RGFW_OS_BASED_VALUE(19, 0x00B, 29, DOM_VK_0, KEY_0)] = RGFW_0 					RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(10, 0x002, 18, DOM_VK_1, KEY_1)] = RGFW_1						RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(11, 0x003, 19, DOM_VK_2, KEY_2)] = RGFW_2						RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(12, 0x004, 20, DOM_VK_3, KEY_3)] = RGFW_3						RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(13, 0x005, 21, DOM_VK_4, KEY_4)] = RGFW_4						RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(14, 0x006, 23, DOM_VK_5, KEY_5)] = RGFW_5                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(15, 0x007, 22, DOM_VK_6, KEY_6)] = RGFW_6                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(16, 0x008, 26, DOM_VK_7, KEY_7)] = RGFW_7                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(17, 0x009, 28, DOM_VK_8, KEY_8)] = RGFW_8                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(18, 0x00A, 25, DOM_VK_9, KEY_9)] = RGFW_9,
 
-	RGFW_MAP [RGFW_OS_BASED_VALUE(65, 0x20, 49, DOM_VK_SPACE, KEY_SPACE)] = RGFW_Space,
+	RGFW_MAP [RGFW_OS_BASED_VALUE(65, 0x039, 49, DOM_VK_SPACE, KEY_SPACE)] = RGFW_Space,
 
-	RGFW_MAP [RGFW_OS_BASED_VALUE(38, 0x41, 0, DOM_VK_A, KEY_A)] = RGFW_a                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(56, 0x42, 11, DOM_VK_B, KEY_B)] = RGFW_b                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(54, 0x43, 8, DOM_VK_C, KEY_C)] = RGFW_c                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(40, 0x44, 2, DOM_VK_D, KEY_D)] = RGFW_d                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(26, 0x45, 14, DOM_VK_E, KEY_E)] = RGFW_e                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(41, 0x46, 3, DOM_VK_F, KEY_F)] = RGFW_f                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(42, 0x47, 5, DOM_VK_G, KEY_G)] = RGFW_g                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(43, 0x48, 4, DOM_VK_H, KEY_H)] = RGFW_h                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(31, 0x49, 34, DOM_VK_I, KEY_I)] = RGFW_i                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(44, 0x4A, 38, DOM_VK_J, KEY_J)] = RGFW_j                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(45, 0x4B, 40, DOM_VK_K, KEY_K)] = RGFW_k                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(46, 0x4C, 37, DOM_VK_L, KEY_L)] = RGFW_l                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(58, 0x4D, 46, DOM_VK_M, KEY_M)] = RGFW_m                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(57, 0x4E, 45, DOM_VK_N, KEY_N)] = RGFW_n                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(32, 0x4F, 31, DOM_VK_O, KEY_O)] = RGFW_o                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(33, 0x50, 35, DOM_VK_P, KEY_P)] = RGFW_p                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(24, 0x51, 12, DOM_VK_Q, KEY_Q)] = RGFW_q                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(27, 0x52, 15, DOM_VK_R, KEY_R)] = RGFW_r                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(39, 0x53, 1, DOM_VK_S, KEY_S)] = RGFW_s                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(28, 0x54, 17, DOM_VK_T, KEY_T)] = RGFW_t                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(30, 0x55, 32, DOM_VK_U, KEY_U)] = RGFW_u                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(55, 0x56, 9, DOM_VK_V, KEY_V)] = RGFW_v                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(25, 0x57, 13, DOM_VK_W, KEY_W)] = RGFW_w                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(53, 0x58, 7, DOM_VK_X, KEY_X)] = RGFW_x                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(29, 0x59, 16, DOM_VK_Y, KEY_Y)] = RGFW_y                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(52, 0x5A, 6, DOM_VK_Z, KEY_Z)] = RGFW_z,
+	RGFW_MAP [RGFW_OS_BASED_VALUE(38, 0x01E, 0, DOM_VK_A, KEY_A)] = RGFW_a                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(56, 0x030, 11, DOM_VK_B, KEY_B)] = RGFW_b                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(54, 0x02E, 8, DOM_VK_C, KEY_C)] = RGFW_c                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(40, 0x020, 2, DOM_VK_D, KEY_D)] = RGFW_d                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(26, 0x012, 14, DOM_VK_E, KEY_E)] = RGFW_e                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(41, 0x021, 3, DOM_VK_F, KEY_F)] = RGFW_f                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(42, 0x022, 5, DOM_VK_G, KEY_G)] = RGFW_g                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(43, 0x023, 4, DOM_VK_H, KEY_H)] = RGFW_h                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(31, 0x017, 34, DOM_VK_I, KEY_I)] = RGFW_i                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(44, 0x024, 38, DOM_VK_J, KEY_J)] = RGFW_j                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(45, 0x025, 40, DOM_VK_K, KEY_K)] = RGFW_k                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(46, 0x026, 37, DOM_VK_L, KEY_L)] = RGFW_l                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(58, 0x032, 46, DOM_VK_M, KEY_M)] = RGFW_m                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(57, 0x031, 45, DOM_VK_N, KEY_N)] = RGFW_n                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(32, 0x018, 31, DOM_VK_O, KEY_O)] = RGFW_o                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(33, 0x019, 35, DOM_VK_P, KEY_P)] = RGFW_p                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(24, 0x010, 12, DOM_VK_Q, KEY_Q)] = RGFW_q                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(27, 0x013, 15, DOM_VK_R, KEY_R)] = RGFW_r                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(39, 0x01F, 1, DOM_VK_S, KEY_S)] = RGFW_s                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(28, 0x014, 17, DOM_VK_T, KEY_T)] = RGFW_t                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(30, 0x016, 32, DOM_VK_U, KEY_U)] = RGFW_u                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(55, 0x02F, 9, DOM_VK_V, KEY_V)] = RGFW_v                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(25, 0x011, 13, DOM_VK_W, KEY_W)] = RGFW_w                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(53, 0x02D, 7, DOM_VK_X, KEY_X)] = RGFW_x                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(29, 0x015, 16, DOM_VK_Y, KEY_Y)] = RGFW_y                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(52, 0x02C, 6, DOM_VK_Z, KEY_Z)] = RGFW_z,
 
-	RGFW_MAP [RGFW_OS_BASED_VALUE(60, 190, 47, DOM_VK_PERIOD, KEY_DOT)] = RGFW_Period             			RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(59, 188, 43, DOM_VK_COMMA, KEY_COMMA)] = RGFW_Comma               			RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(61, 191, 44, DOM_VK_SLASH, KEY_SLASH)] = RGFW_Slash               			RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(34, 219, 33, DOM_VK_OPEN_BRACKET, KEY_LEFTBRACE)] = RGFW_Bracket      			RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(35, 221, 30, DOM_VK_CLOSE_BRACKET, KEY_RIGHTBRACE)] = RGFW_CloseBracket             RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(47, 186, 41, DOM_VK_SEMICOLON, KEY_SEMICOLON)] = RGFW_Semicolon                 RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(48, 222, 39, DOM_VK_QUOTE, KEY_APOSTROPHE)] = RGFW_Quote                 			RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(51, 322, 42, DOM_VK_BACK_SLASH, KEY_BACKSLASH)] = RGFW_BackSlash,
+	RGFW_MAP [RGFW_OS_BASED_VALUE(60, 0x034, 47, DOM_VK_PERIOD, KEY_DOT)] = RGFW_Period             			RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(59, 0x033, 43, DOM_VK_COMMA, KEY_COMMA)] = RGFW_Comma               			RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(61, 0x035, 44, DOM_VK_SLASH, KEY_SLASH)] = RGFW_Slash               			RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(34, 0x01A, 33, DOM_VK_OPEN_BRACKET, KEY_LEFTBRACE)] = RGFW_Bracket      			RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(35, 0x01B, 30, DOM_VK_CLOSE_BRACKET, KEY_RIGHTBRACE)] = RGFW_CloseBracket             RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(47, 0x027, 41, DOM_VK_SEMICOLON, KEY_SEMICOLON)] = RGFW_Semicolon                 RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(48, 0x028, 39, DOM_VK_QUOTE, KEY_APOSTROPHE)] = RGFW_Quote                 			RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(51, 0x02B, 42, DOM_VK_BACK_SLASH, KEY_BACKSLASH)] = RGFW_BackSlash,
 	
-	RGFW_MAP [RGFW_OS_BASED_VALUE(36, 0x0D, 36, DOM_VK_RETURN, KEY_ENTER)] = RGFW_Return              RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(119, 0x2E, 118, DOM_VK_DELETE, KEY_DELETE)] = RGFW_Delete                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(77, 0x90, 72, DOM_VK_NUM_LOCK, KEY_NUMLOCK)] = RGFW_Numlock               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(106, 0x6F, 82, DOM_VK_DIVIDE, KEY_KPSLASH)] = RGFW_KP_Slash               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(63, 0x6A, 76, DOM_VK_MULTIPLY, KEY_KPASTERISK)] = RGFW_Multiply              RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(82, 0x6D, 67, DOM_VK_SUBTRACT, KEY_KPMINUS)] = RGFW_KP_Minus              RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(87, 0x61, 84, DOM_VK_NUMPAD1, KEY_KP1)] = RGFW_KP_1               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(88, 0x62, 85, DOM_VK_NUMPAD2, KEY_KP2)] = RGFW_KP_2               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(89, 0x63, 86, DOM_VK_NUMPAD3, KEY_KP3)] = RGFW_KP_3               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(83, 0x64, 87, DOM_VK_NUMPAD4, KEY_KP4)] = RGFW_KP_4               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(84, 0x65, 88, DOM_VK_NUMPAD5, KEY_KP5)] = RGFW_KP_5               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(85, 0x66, 89, DOM_VK_NUMPAD6, KEY_KP6)] = RGFW_KP_6               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(79, 0x67, 90, DOM_VK_NUMPAD7, KEY_KP7)] = RGFW_KP_7               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(80, 0x68, 92, DOM_VK_NUMPAD8, KEY_KP8)] = RGFW_KP_8               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(81, 0x69, 93, DOM_VK_NUMPAD9, KEY_KP9)] = RGFW_KP_9               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(90, 0x60, 83, DOM_VK_NUMPAD0, KEY_KP0)] = RGFW_KP_0               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(91, 0x6E, 65, DOM_VK_DECIMAL, KEY_KPDOT)] = RGFW_KP_Period              RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(104, 0x92, 77, 0, KEY_KPENTER)] = RGFW_KP_Return,
+	RGFW_MAP [RGFW_OS_BASED_VALUE(36, 0x01C, 36, DOM_VK_RETURN, KEY_ENTER)] = RGFW_Return              RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(119, 0x153, 118, DOM_VK_DELETE, KEY_DELETE)] = RGFW_Delete                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(77, 0x145, 72, DOM_VK_NUM_LOCK, KEY_NUMLOCK)] = RGFW_Numlock               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(106, 0x135, 82, DOM_VK_DIVIDE, KEY_KPSLASH)] = RGFW_KP_Slash               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(63, 0x037, 76, DOM_VK_MULTIPLY, KEY_KPASTERISK)] = RGFW_Multiply              RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(82, 0x04A, 67, DOM_VK_SUBTRACT, KEY_KPMINUS)] = RGFW_KP_Minus              RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(87, 0x04F, 84, DOM_VK_NUMPAD1, KEY_KP1)] = RGFW_KP_1               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(88, 0x050, 85, DOM_VK_NUMPAD2, KEY_KP2)] = RGFW_KP_2               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(89, 0x051, 86, DOM_VK_NUMPAD3, KEY_KP3)] = RGFW_KP_3               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(83, 0x04B, 87, DOM_VK_NUMPAD4, KEY_KP4)] = RGFW_KP_4               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(84, 0x04C, 88, DOM_VK_NUMPAD5, KEY_KP5)] = RGFW_KP_5               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(85, 0x04D, 89, DOM_VK_NUMPAD6, KEY_KP6)] = RGFW_KP_6               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(79, 0x047, 90, DOM_VK_NUMPAD7, KEY_KP7)] = RGFW_KP_7               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(80, 0x048, 92, DOM_VK_NUMPAD8, KEY_KP8)] = RGFW_KP_8               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(81, 0x049, 93, DOM_VK_NUMPAD9, KEY_KP9)] = RGFW_KP_9               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(90, 0x052, 83, DOM_VK_NUMPAD0, KEY_KP0)] = RGFW_KP_0               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(91, 0x053, 65, DOM_VK_DECIMAL, KEY_KPDOT)] = RGFW_KP_Period              RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(104, 0x11C, 77, 0, KEY_KPENTER)] = RGFW_KP_Return,
 	
-	RGFW_MAP [RGFW_OS_BASED_VALUE(20, 189, 27, DOM_VK_HYPHEN_MINUS, KEY_MINUS)] = RGFW_Minus              RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(21, 187, 24, DOM_VK_EQUALS, KEY_EQUAL)] = RGFW_Equals               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(22, 8, 51, DOM_VK_BACK_SPACE, KEY_BACKSPACE)] = RGFW_BackSpace              RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(23, 0x09, 48, DOM_VK_TAB, KEY_TAB)] = RGFW_Tab                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(66, 20, 57, DOM_VK_CAPS_LOCK, KEY_CAPSLOCK)] = RGFW_CapsLock               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(50, 0x10, 56, DOM_VK_SHIFT, KEY_LEFTSHIFT)] = RGFW_ShiftL               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(37, 0x11, 59, DOM_VK_CONTROL, KEY_LEFTCTRL)] = RGFW_ControlL               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(64,0x12, 58, DOM_VK_ALT, KEY_LEFTALT)] = RGFW_AltL                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(133, 0x5B, 55, DOM_VK_WIN, KEY_LEFTMETA)] = RGFW_SuperL,
+	RGFW_MAP [RGFW_OS_BASED_VALUE(20, 0x00C, 27, DOM_VK_HYPHEN_MINUS, KEY_MINUS)] = RGFW_Minus              RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(21, 0x00D, 24, DOM_VK_EQUALS, KEY_EQUAL)] = RGFW_Equals               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(22, 0x00E, 51, DOM_VK_BACK_SPACE, KEY_BACKSPACE)] = RGFW_BackSpace              RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(23, 0x00F, 48, DOM_VK_TAB, KEY_TAB)] = RGFW_Tab                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(66, 0x03A, 57, DOM_VK_CAPS_LOCK, KEY_CAPSLOCK)] = RGFW_CapsLock               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(50, 0x02A, 56, DOM_VK_SHIFT, KEY_LEFTSHIFT)] = RGFW_ShiftL               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(37, 0x01D, 59, DOM_VK_CONTROL, KEY_LEFTCTRL)] = RGFW_ControlL               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(64, 0x038, 58, DOM_VK_ALT, KEY_LEFTALT)] = RGFW_AltL                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(133, 0x15B, 55, DOM_VK_WIN, KEY_LEFTMETA)] = RGFW_SuperL,
 	
-	#if !defined(RGFW_WINDOWS) && !defined(RGFW_MACOS) && !defined(RGFW_WEBASM)
-	RGFW_MAP [RGFW_OS_BASED_VALUE(105, 0x11, 59, 0, KEY_RIGHTCTRL)] = RGFW_ControlR               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(135, 0xA4, 55, 0, KEY_RIGHTMETA)] = RGFW_SuperR,
-	RGFW_MAP [RGFW_OS_BASED_VALUE(62, 0x5C, 56, 0, KEY_RIGHTSHIFT)] = RGFW_ShiftR              RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(108, 165, 58, 0, KEY_RIGHTALT)] = RGFW_AltR,
+	#if !defined(RGFW_MACOS) && !defined(RGFW_WEBASM)
+	RGFW_MAP [RGFW_OS_BASED_VALUE(105, 0x11D, 59, 0, KEY_RIGHTCTRL)] = RGFW_ControlR               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(135, 0x15C, 55, 0, KEY_RIGHTMETA)] = RGFW_SuperR,
+	RGFW_MAP [RGFW_OS_BASED_VALUE(62, 0x036, 56, 0, KEY_RIGHTSHIFT)] = RGFW_ShiftR              RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(108, 0x138, 58, 0, KEY_RIGHTALT)] = RGFW_AltR,
 	#endif
 
-	RGFW_MAP [RGFW_OS_BASED_VALUE(67, 0x70, 127, DOM_VK_F1, KEY_F1)] = RGFW_F1                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(68, 0x71, 121, DOM_VK_F2, KEY_F2)] = RGFW_F2                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(69, 0x72, 100, DOM_VK_F3, KEY_F3)] = RGFW_F3                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(70, 0x73, 119, DOM_VK_F4, KEY_F4)] = RGFW_F4                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(71, 0x74, 97, DOM_VK_F5, KEY_F5)] = RGFW_F5              RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(72, 0x75, 98, DOM_VK_F6, KEY_F6)] = RGFW_F6              RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(73, 0x76, 99, DOM_VK_F7, KEY_F7)] = RGFW_F7              RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(74, 0x77, 101, DOM_VK_F8, KEY_F8)] = RGFW_F8                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(75, 0x78, 102, DOM_VK_F9, KEY_F9)] = RGFW_F9                 		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(76, 0x79, 110, DOM_VK_F10, KEY_F10)] = RGFW_F10               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(95, 0x7A, 104, DOM_VK_F11, KEY_F11)] = RGFW_F11               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(96, 0x7B, 112, DOM_VK_F12, KEY_F12)] = RGFW_F12               RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(111, 0x26, 126, DOM_VK_UP, KEY_UP)] = RGFW_Up                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(116, 0x28, 125, DOM_VK_DOWN, KEY_DOWN)] = RGFW_Down                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(113, 0x25, 123, DOM_VK_LEFT, KEY_LEFT)] = RGFW_Left                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(114, 0x27, 124, DOM_VK_RIGHT, KEY_RIGHT)] = RGFW_Right              RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(118, 0x2D, 115, DOM_VK_INSERT, KEY_INSERT)] = RGFW_Insert                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(115, 0x23, 120, DOM_VK_END, KEY_END)] = RGFW_End                  		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(112, 336, 117, DOM_VK_PAGE_UP, KEY_PAGEUP)] = RGFW_PageUp                		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(117, 325, 122, DOM_VK_PAGE_DOWN, KEY_PAGEDOWN)] = RGFW_PageDown            RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(9, 0x1B, 53, DOM_VK_ESCAPE, KEY_ESC)] = RGFW_Escape                   		RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(110, 0x24, 116, DOM_VK_HOME, KEY_HOME)] = RGFW_Home                    		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(67, 0x03B, 127, DOM_VK_F1, KEY_F1)] = RGFW_F1                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(68, 0x03C, 121, DOM_VK_F2, KEY_F2)] = RGFW_F2                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(69, 0x03D, 100, DOM_VK_F3, KEY_F3)] = RGFW_F3                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(70, 0x03E, 119, DOM_VK_F4, KEY_F4)] = RGFW_F4                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(71, 0x03F, 97, DOM_VK_F5, KEY_F5)] = RGFW_F5              RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(72, 0x040, 98, DOM_VK_F6, KEY_F6)] = RGFW_F6              RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(73, 0x041, 99, DOM_VK_F7, KEY_F7)] = RGFW_F7              RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(74, 0x042, 101, DOM_VK_F8, KEY_F8)] = RGFW_F8                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(75, 0x043, 102, DOM_VK_F9, KEY_F9)] = RGFW_F9                 		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(76, 0x044, 110, DOM_VK_F10, KEY_F10)] = RGFW_F10               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(95, 0x057, 104, DOM_VK_F11, KEY_F11)] = RGFW_F11               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(96, 0x058, 112, DOM_VK_F12, KEY_F12)] = RGFW_F12               RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(111, 0x148, 126, DOM_VK_UP, KEY_UP)] = RGFW_Up                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(116, 0x150, 125, DOM_VK_DOWN, KEY_DOWN)] = RGFW_Down                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(113, 0x14B, 123, DOM_VK_LEFT, KEY_LEFT)] = RGFW_Left                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(114, 0x14D, 124, DOM_VK_RIGHT, KEY_RIGHT)] = RGFW_Right              RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(118, 0x152, 115, DOM_VK_INSERT, KEY_INSERT)] = RGFW_Insert                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(115, 0x14F, 120, DOM_VK_END, KEY_END)] = RGFW_End                  		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(112, 0x149, 117, DOM_VK_PAGE_UP, KEY_PAGEUP)] = RGFW_PageUp                		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(117, 0x151, 122, DOM_VK_PAGE_DOWN, KEY_PAGEDOWN)] = RGFW_PageDown            RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(9, 0x001, 53, DOM_VK_ESCAPE, KEY_ESC)] = RGFW_Escape                   		RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(110, 0x147, 116, DOM_VK_HOME, KEY_HOME)] = RGFW_Home                    		RGFW_NEXT
 #ifndef __cplusplus
 };
 #else 
@@ -1396,10 +1396,10 @@ typedef struct {
 
 RGFW_keyState RGFW_keyboard[final_key] = { {0, 0} };
 
-RGFWDEF u32 RGFW_apiMappedToRGFW(u32 keycode);
-RGFWDEF u32 RGFW_apiPhysicalToRGFW(u32 physicalKey);
+RGFWDEF u32 RGFW_apiPhysicalToRGFW(u32 keycode);
+RGFWDEF u32 RGFW_apiMappedToRGFW(u32 mappedKey);
 
-u32 RGFW_apiMappedToRGFW(u32 keycode) {
+u32 RGFW_apiPhysicalToRGFW(u32 keycode) {
 	#ifdef __cplusplus
 	if (RGFW_OS_BASED_VALUE(49, 192, 50, DOM_VK_BACK_QUOTE, KEY_GRAVE) != RGFW_Backtick) {
 		RGFW_init_keys();
@@ -1414,7 +1414,7 @@ u32 RGFW_apiMappedToRGFW(u32 keycode) {
 }
 
 #ifndef RGFW_WINDOWS
-u32 RGFW_apiPhysicalToRGFW(u32 physicalKey) {
+u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
 	return 0;
 }
 #endif
@@ -1488,7 +1488,7 @@ void RGFW_mouseNotifyfuncEMPTY(RGFW_window* win, RGFW_point point, b8 status) {R
 void RGFW_mouseposfuncEMPTY(RGFW_window* win, RGFW_point point) {RGFW_UNUSED(win); RGFW_UNUSED(point);}
 void RGFW_dndInitfuncEMPTY(RGFW_window* win, RGFW_point point) {RGFW_UNUSED(win); RGFW_UNUSED(point);}
 void RGFW_windowrefreshfuncEMPTY(RGFW_window* win) {RGFW_UNUSED(win); }
-void RGFW_keyfuncEMPTY(RGFW_window* win, u32 mappedKey, u32 physicalKey, char keyName[16], u8 lockState, b8 pressed) {RGFW_UNUSED(win); RGFW_UNUSED(mappedKey); RGFW_UNUSED(physicalKey); RGFW_UNUSED(keyName); RGFW_UNUSED(lockState); RGFW_UNUSED(pressed);}
+void RGFW_keyfuncEMPTY(RGFW_window* win, u32 physicalKey, u32 mappedKey, char keyName[16], u8 lockState, b8 pressed) {RGFW_UNUSED(win); RGFW_UNUSED(physicalKey); RGFW_UNUSED(mappedKey); RGFW_UNUSED(keyName); RGFW_UNUSED(lockState); RGFW_UNUSED(pressed);}
 void RGFW_mousebuttonfuncEMPTY(RGFW_window* win, u8 button, double scroll, b8 pressed) {RGFW_UNUSED(win); RGFW_UNUSED(button); RGFW_UNUSED(scroll); RGFW_UNUSED(pressed);}
 void RGFW_gpButtonfuncEMPTY(RGFW_window* win, u16 gamepad, u8 button, b8 pressed){RGFW_UNUSED(win); RGFW_UNUSED(gamepad); RGFW_UNUSED(button); RGFW_UNUSED(pressed); }
 void RGFW_gpAxisfuncEMPTY(RGFW_window* win, u16 gamepad, RGFW_point axis[2], u8 axisesCount){RGFW_UNUSED(win); RGFW_UNUSED(gamepad); RGFW_UNUSED(axis); RGFW_UNUSED(axisesCount); }
@@ -2843,15 +2843,15 @@ Start of Linux / Unix defines
 					XEvent NE;
 					XPeekEvent((Display*) win->src.display, &NE);
 
-					if (E.xkey.time == NE.xkey.time && E.xkey.mappedKey == NE.xkey.keycode) /* check if the current and next are both the same*/
+					if (E.xkey.time == NE.xkey.time && E.xkey.physicalKey == NE.xkey.keycode) /* check if the current and next are both the same*/
 						win->event.repeat = RGFW_TRUE;
 				}
 
 				/* set event key data */
-				KeySym sym = (KeySym)XkbKeycodeToKeysym((Display*) win->src.display, E.xkey.mappedKey, 0, E.xkey.state & ShiftMask ? 1 : 0);
-				win->event.mappedKey = RGFW_apiMappedToRGFW(E.xkey.keycode);
+				KeySym sym = (KeySym)XkbKeycodeToKeysym((Display*) win->src.display, E.xkey.physicalKey, 0, E.xkey.state & ShiftMask ? 1 : 0);
+				win->event.physicalKey = RGFW_apiPhysicalToRGFW(E.xkey.keycode);
 
-				win->event.mappedKey = RGFW_apiPhysicalToRGFW(physicalKey);
+				win->event.physicalKey = RGFW_apiPhysicalToRGFW(mappedKey);
 				
 				char* str = (char*)XKeysymToString(sym);
 				if (str != NULL)
@@ -2859,7 +2859,7 @@ Start of Linux / Unix defines
 
 				win->event.keyName[15] = '\0';		
 
-				RGFW_keyboard[win->event.mappedKey].prev = RGFW_isPressed(win, win->event.mappedKey);
+				RGFW_keyboard[win->event.physicalKey].prev = RGFW_isPressed(win, win->event.physicalKey);
 				
 				/* get keystate data */
 				win->event.type = (E.type == KeyPress) ? RGFW_keyPressed : RGFW_keyReleased;
@@ -2868,8 +2868,8 @@ Start of Linux / Unix defines
 				XGetKeyboardControl((Display*) win->src.display, &keystate);
 
 				RGFW_updateLockState(win, (keystate.led_mask & 1), (keystate.led_mask & 2));
-				RGFW_keyboard[win->event.mappedKey].current = (E.type == KeyPress);
-				RGFW_keyCallback(win, win->event.mappedKey, win->event.physicalKey, win->event.keyName, win->event.lockState, (E.type == KeyPress));
+				RGFW_keyboard[win->event.physicalKey].current = (E.type == KeyPress);
+				RGFW_keyCallback(win, win->event.physicalKey, win->event.mappedKey, win->event.keyName, win->event.lockState, (E.type == KeyPress));
 				break;
 			}
 			case ButtonPress:
@@ -2890,7 +2890,7 @@ Start of Linux / Unix defines
 				RGFW_mouseButtons[win->event.button].prev = RGFW_mouseButtons[win->event.button].current;
 
 				if (win->event.repeat == RGFW_FALSE)
-					win->event.repeat = RGFW_isPressed(win, win->event.mappedKey);
+					win->event.repeat = RGFW_isPressed(win, win->event.physicalKey);
 
 				RGFW_mouseButtons[win->event.button].current = (E.type == ButtonPress);
 				RGFW_mouseButtonCallback(win, win->event.button, win->event.scroll, (E.type == ButtonPress));
@@ -4448,12 +4448,12 @@ static void keyboard_key (void *data, struct wl_keyboard *keyboard, uint32_t ser
 	char name[16];
 	xkb_keysym_get_name(keysym, name, 16);
 
-	u32 RGFW_key = RGFW_apiMappedToRGFW(key);
+	u32 RGFW_key = RGFW_apiPhysicalToRGFW(key);
 	RGFW_keyboard[RGFW_key].prev = RGFW_keyboard[RGFW_key].current;
 	RGFW_keyboard[RGFW_key].current = state;
 	RGFW_Event ev;
 	ev.type = RGFW_keyPressed + state;
-	ev.mappedKey = RGFW_key;
+	ev.physicalKey = RGFW_key;
 	strcpy(ev.keyName, name);
 	ev.repeat = RGFW_isHeld(RGFW_key_win, RGFW_key);
 	RGFW_eventPipe_push(RGFW_key_win, ev);
@@ -5238,8 +5238,8 @@ static HMODULE wglinstance = NULL;
 		}
 	}
 
-	u32 RGFW_apiPhysicalToRGFW(u32 physicalKey) {
-		return RGFW_apiMappedToRGFW(MapVirtualKeyW((u32)physicalKey, MAPVK_VSC_TO_VK));
+	u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
+		return RGFW_apiPhysicalToRGFW(MapVirtualKeyW((u32)mappedKey, MAPVK_VSC_TO_VK));
 	}
 	
 	#ifndef RGFW_NO_DPI
@@ -5922,18 +5922,18 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 				break;
 			
 			case WM_KEYUP: {
-				i32 physicalKey = (HIWORD(msg.lParam) & (KF_EXTENDED | 0xff));
-				if (physicalKey == 0)
-					physicalKey = MapVirtualKeyW((u32)msg.wParam, MAPVK_VK_TO_VSC);
+				i32 scancode = (HIWORD(msg.lParam) & (KF_EXTENDED | 0xff));
+				if (scancode == 0)
+					scancode = MapVirtualKeyW((u32)msg.wParam, MAPVK_VK_TO_VSC);
 
-				switch (physicalKey) {
-					case 0x54: physicalKey = 0x137; break; /*  Alt+PrtS */
-					case 0x146: physicalKey = 0x45; break; /* Ctrl+Pause */
-					case 0x136: physicalKey = 0x36; break; /*  CJK IME sets the extended bit for right Shift */
+				switch (scancode) {
+					case 0x54: scancode = 0x137; break; /*  Alt+PrtS */
+					case 0x146: scancode = 0x45; break; /* Ctrl+Pause */
+					case 0x136: scancode = 0x36; break; /*  CJK IME sets the extended bit for right Shift */
 					default: break;
-				}
-				printf("%i\n", physicalKey);
-				win->event.physicalKey = RGFW_apiPhysicalToRGFW((u32)physicalKey);
+				}	
+
+				win->event.physicalKey = RGFW_apiPhysicalToRGFW((u32) scancode);
 
 				if (msg.wParam == VK_CONTROL) {
 					if (HIWORD(msg.lParam) & KF_EXTENDED)
@@ -5941,9 +5941,9 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 					else win->event.physicalKey = RGFW_ControlL;
 				}
 
-				win->event.mappedKey = RGFW_apiMappedToRGFW((u32) msg.wParam);
+				win->event.mappedKey = RGFW_apiMappedToRGFW((u32)msg.wParam);
 								
-				RGFW_keyboard[win->event.mappedKey].prev = RGFW_isPressed(win, win->event.mappedKey);
+				RGFW_keyboard[win->event.physicalKey].prev = RGFW_isPressed(win, win->event.physicalKey);
 
 				static char keyName[16];
 				
@@ -5965,26 +5965,33 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 				}
 
 				win->event.type = RGFW_keyReleased;
-				RGFW_keyboard[win->event.mappedKey].current = 0;
-				RGFW_keyCallback(win, win->event.mappedKey, win->event.physicalKey, win->event.keyName, win->event.lockState, 0);
+				RGFW_keyboard[win->event.physicalKey].current = 0;
+				RGFW_keyCallback(win, win->event.physicalKey, win->event.mappedKey, win->event.keyName, win->event.lockState, 0);
 				break;
 			}
 			case WM_KEYDOWN: {
-				i32 physicalKey = (HIWORD(msg.lParam) & (KF_EXTENDED | 0xff));
-				if (physicalKey == 0)
-					physicalKey = MapVirtualKeyW((u32)msg.wParam, MAPVK_VK_TO_VSC);
+				i32 scancode = (HIWORD(msg.lParam) & (KF_EXTENDED | 0xff));
+				if (scancode == 0)
+					scancode = MapVirtualKeyW((u32)msg.wParam, MAPVK_VK_TO_VSC);
 
-				switch (physicalKey) {
-					case 0x54: physicalKey = 0x137; break; /*  Alt+PrtS */
-					case 0x146: physicalKey = 0x45; break; /* Ctrl+Pause */
-					case 0x136: physicalKey = 0x36; break; /*  CJK IME sets the extended bit for right Shift */
+				switch (scancode) {
+					case 0x54: scancode = 0x137; break; /*  Alt+PrtS */
+					case 0x146: scancode = 0x45; break; /* Ctrl+Pause */
+					case 0x136: scancode = 0x36; break; /*  CJK IME sets the extended bit for right Shift */
 					default: break;
-				}
-				
-				win->event.physicalKey = RGFW_apiPhysicalToRGFW((u32)physicalKey);
-				win->event.mappedKey = RGFW_apiMappedToRGFW((u32) msg.wParam);
+				}	
 
-				RGFW_keyboard[win->event.mappedKey].prev = RGFW_isPressed(win, win->event.mappedKey);
+				win->event.physicalKey = RGFW_apiPhysicalToRGFW((u32) scancode);
+
+				if (msg.wParam == VK_CONTROL) {
+					if (HIWORD(msg.lParam) & KF_EXTENDED)
+						win->event.physicalKey = RGFW_ControlR;
+					else win->event.physicalKey = RGFW_ControlL;
+				}
+
+				win->event.mappedKey = RGFW_apiMappedToRGFW((u32)msg.wParam);
+				
+				RGFW_keyboard[win->event.physicalKey].prev = RGFW_isPressed(win, win->event.physicalKey);
 
 				static char keyName[16];
 				
@@ -6007,9 +6014,9 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 				}
 
 				win->event.type = RGFW_keyPressed;
-				win->event.repeat = RGFW_isPressed(win, win->event.mappedKey);
-				RGFW_keyboard[win->event.mappedKey].current = 1;
-				RGFW_keyCallback(win, win->event.mappedKey, win->event.physicalKey, win->event.keyName, win->event.lockState, 1);
+				win->event.repeat = RGFW_isPressed(win, win->event.physicalKey);
+				RGFW_keyboard[win->event.physicalKey].current = 1;
+				RGFW_keyCallback(win, win->event.physicalKey, win->event.mappedKey, win->event.keyName, win->event.lockState, 1);
 				break;
 			}
 
@@ -7763,8 +7770,8 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 		if (eventFunc == NULL) 
 			eventFunc = sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:");
 
-		if ((win->event.type == RGFW_windowMoved || win->event.type == RGFW_windowResized || win->event.type == RGFW_windowRefresh) && win->event.mappedKey != 120) {
-			win->event.mappedKey = 120;
+		if ((win->event.type == RGFW_windowMoved || win->event.type == RGFW_windowResized || win->event.type == RGFW_windowRefresh) && win->event.physicalKey != 120) {
+			win->event.physicalKey = 120;
 			objc_msgSend_bool_void(eventPool, sel_registerName("drain"));
 			return &win->event;
 		}
@@ -7813,33 +7820,33 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 
 			case NSEventTypeKeyDown: {
 				u32 key = (u16) objc_msgSend_uint(e, sel_registerName("keyCode"));
-				win->event.physicalKey = RGFW_apiPhysicalToRGFW((u32)physicalKey);
-				win->event.mappedKey = RGFW_apiMappedToRGFW(key);
-				RGFW_keyboard[win->event.mappedKey].prev = RGFW_keyboard[win->event.mappedKey].current;
+				win->event.mappedKey = RGFW_apiPhysicalToRGFW((u32)mappedKey);
+				win->event.physicalKey = RGFW_apiPhysicalToRGFW(key);
+				RGFW_keyboard[win->event.physicalKey].prev = RGFW_keyboard[win->event.physicalKey].current;
 
 				win->event.type = RGFW_keyPressed;
 				char* str = (char*)(const char*) NSString_to_char(objc_msgSend_id(e, sel_registerName("characters")));
 				strncpy(win->event.keyName, str, 16);
-				win->event.repeat = RGFW_isPressed(win, win->event.mappedKey);
-				RGFW_keyboard[win->event.mappedKey].current = 1;
+				win->event.repeat = RGFW_isPressed(win, win->event.physicalKey);
+				RGFW_keyboard[win->event.physicalKey].current = 1;
 
-				RGFW_keyCallback(win, win->event.mappedKey, win->event.physicalKey, win->event.keyName, win->event.lockState, 1);
+				RGFW_keyCallback(win, win->event.physicalKey, win->event.mappedKey, win->event.keyName, win->event.lockState, 1);
 				break;
 			}
 
 			case NSEventTypeKeyUp: {
 				u32 key = (u16) objc_msgSend_uint(e, sel_registerName("keyCode"));
-				win->event.physicalKey = RGFW_apiPhysicalToRGFW((u32)physicalKey);
-				win->event.mappedKey = RGFW_apiMappedToRGFW(key);
+				win->event.mappedKey = RGFW_apiPhysicalToRGFW((u32)mappedKey);
+				win->event.physicalKey = RGFW_apiPhysicalToRGFW(key);
 
-				RGFW_keyboard[win->event.mappedKey].prev = RGFW_keyboard[win->event.mappedKey].current;
+				RGFW_keyboard[win->event.physicalKey].prev = RGFW_keyboard[win->event.physicalKey].current;
 
 				win->event.type = RGFW_keyReleased;
 				char* str = (char*)(const char*) NSString_to_char(objc_msgSend_id(e, sel_registerName("characters")));
 				strncpy(win->event.keyName, str, 16);
 
-				RGFW_keyboard[win->event.mappedKey].current = 0;
-				RGFW_keyCallback(win, win->event.mappedKey, win->event.physicalKey, win->event.keyName, win->event.lockState, 0);
+				RGFW_keyboard[win->event.physicalKey].current = 0;
+				RGFW_keyCallback(win, win->event.physicalKey, win->event.mappedKey, win->event.keyName, win->event.lockState, 0);
 				break;
 			}
 
@@ -7862,7 +7869,7 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 							RGFW_keyboard[key+ 4].current = 1;
 						
 						win->event.type = RGFW_keyPressed;
-						win->event.mappedKey = key;
+						win->event.physicalKey = key;
 						break;
 					} 
 					
@@ -7873,12 +7880,12 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 							RGFW_keyboard[key + 4].current = 0;
 
 						win->event.type = RGFW_keyReleased;
-						win->event.mappedKey = key;
+						win->event.physicalKey = key;
 						break;
 					}
 				}
 
-				RGFW_keyCallback(win, win->event.mappedKey, win->event.physicalKey, win->event.keyName, win->event.lockState, win->event.type == RGFW_keyPressed);
+				RGFW_keyCallback(win, win->event.physicalKey, win->event.mappedKey, win->event.keyName, win->event.lockState, win->event.type == RGFW_keyPressed);
 
 				break;
 			}
@@ -8421,15 +8428,15 @@ EM_BOOL Emscripten_on_keydown(int eventType, const EmscriptenKeyboardEvent* e, v
 	
 	RGFW_events[RGFW_eventLen].type = RGFW_keyPressed;
 	memcpy(RGFW_events[RGFW_eventLen].keyName, e->key, 16);
-	RGFW_events[RGFW_eventLen].physicalKey = RGFW_apiPhysicalToRGFW((u32)physicalKey);
-	RGFW_events[RGFW_eventLen].physicalKey = RGFW_apiPhysicalToRGFW((u32)physicalKey);
-	RGFW_events[RGFW_eventLen].mappedKey = RGFW_apiMappedToRGFW(e->keyCode);
+	RGFW_events[RGFW_eventLen].mappedKey = RGFW_apiPhysicalToRGFW((u32)mappedKey);
+	RGFW_events[RGFW_eventLen].mappedKey = RGFW_apiPhysicalToRGFW((u32)mappedKey);
+	RGFW_events[RGFW_eventLen].physicalKey = RGFW_apiPhysicalToRGFW(e->keyCode);
 	RGFW_events[RGFW_eventLen].lockState = 0;
 	RGFW_eventLen++;
 
-	RGFW_keyboard[RGFW_apiMappedToRGFW(e->keyCode)].prev = RGFW_keyboard[RGFW_apiMappedToRGFW(e->keyCode)].current;
-	RGFW_keyboard[RGFW_apiMappedToRGFW(e->keyCode)].current = 1;
-	RGFW_keyCallback(RGFW_root, RGFW_apiMappedToRGFW(e->keyCode), RGFW_events[RGFW_eventLen].keyName, 0, 1);
+	RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].prev = RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].current;
+	RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].current = 1;
+	RGFW_keyCallback(RGFW_root, RGFW_apiPhysicalToRGFW(e->keyCode), RGFW_events[RGFW_eventLen].keyName, 0, 1);
 	
     return EM_TRUE;
 }
@@ -8439,14 +8446,14 @@ EM_BOOL Emscripten_on_keyup(int eventType, const EmscriptenKeyboardEvent* e, voi
 
 	RGFW_events[RGFW_eventLen].type = RGFW_keyReleased;
 	memcpy(RGFW_events[RGFW_eventLen].keyName, e->key, 16);
-	RGFW_events[RGFW_eventLen].mappedKey = RGFW_apiMappedToRGFW(e->keyCode);
+	RGFW_events[RGFW_eventLen].physicalKey = RGFW_apiPhysicalToRGFW(e->keyCode);
 	RGFW_events[RGFW_eventLen].lockState = 0;
 	RGFW_eventLen++;
 
-	RGFW_keyboard[RGFW_apiMappedToRGFW(e->keyCode)].prev = RGFW_keyboard[RGFW_apiMappedToRGFW(e->keyCode)].current;
-	RGFW_keyboard[RGFW_apiMappedToRGFW(e->keyCode)].current = 0;
+	RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].prev = RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].current;
+	RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].current = 0;
 
-	RGFW_keyCallback(RGFW_root, RGFW_apiMappedToRGFW(e->keyCode), RGFW_events[RGFW_eventLen].keyName, 0, 0);
+	RGFW_keyCallback(RGFW_root, RGFW_apiPhysicalToRGFW(e->keyCode), RGFW_events[RGFW_eventLen].keyName, 0, 0);
 
     return EM_TRUE;
 }

--- a/RGFW.h
+++ b/RGFW.h
@@ -8713,125 +8713,130 @@ EM_BOOL Emscripten_on_gamepad(int eventType, const EmscriptenGamepadEvent *gamep
     return 1; // The event was consumed by the callback handler
 }
 
+
+u32 RGFW_webasmPhysicalToRGFW(u32 hash) {
+	switch(hash) {             /* 0x0000 */
+		case 0x67243A2DU /* Escape             */: return RGFW_Escape;               /* 0x0001 */
+		case 0x67251058U /* Digit0             */: return RGFW_0;                    /* 0x0002 */
+		case 0x67251059U /* Digit1             */: return RGFW_1;                    /* 0x0003 */
+		case 0x6725105AU /* Digit2             */: return RGFW_2;                    /* 0x0004 */
+		case 0x6725105BU /* Digit3             */: return RGFW_3;                    /* 0x0005 */
+		case 0x6725105CU /* Digit4             */: return RGFW_4;                    /* 0x0006 */
+		case 0x6725105DU /* Digit5             */: return RGFW_5;                    /* 0x0007 */
+		case 0x6725105EU /* Digit6             */: return RGFW_6;                    /* 0x0008 */
+		case 0x6725105FU /* Digit7             */: return RGFW_7;                    /* 0x0009 */
+		case 0x67251050U /* Digit8             */: return RGFW_8;                    /* 0x000A */
+		case 0x67251051U /* Digit9             */: return RGFW_9;                    /* 0x000B */
+		case 0x92E14DD3U /* Minus              */: return RGFW_Minus;                /* 0x000C */
+		case 0x92E1FBACU /* Equal              */: return RGFW_Equals;                /* 0x000D */
+		case 0x36BF1CB5U /* Backspace          */: return RGFW_BackSpace;            /* 0x000E */
+		case 0x7B8E51E2U /* Tab                */: return RGFW_Tab;                  /* 0x000F */
+		case 0x2C595B51U /* KeyQ               */: return RGFW_q;                    /* 0x0010 */
+		case 0x2C595B57U /* KeyW               */: return RGFW_w;                    /* 0x0011 */
+		case 0x2C595B45U /* KeyE               */: return RGFW_e;                    /* 0x0012 */
+		case 0x2C595B52U /* KeyR               */: return RGFW_r;                    /* 0x0013 */
+		case 0x2C595B54U /* KeyT               */: return RGFW_t;                    /* 0x0014 */
+		case 0x2C595B59U /* KeyY               */: return RGFW_y;                    /* 0x0015 */
+		case 0x2C595B55U /* KeyU               */: return RGFW_u;                    /* 0x0016 */
+		case 0x2C595B4FU /* KeyO               */: return RGFW_o;                    /* 0x0018 */
+		case 0x2C595B50U /* KeyP               */: return RGFW_p;                    /* 0x0019 */
+		case 0x45D8158CU /* BracketLeft        */: return RGFW_CloseBracket;         /* 0x001A */
+		case 0xDEEABF7CU /* BracketRight       */: return RGFW_Bracket;        /* 0x001B */
+		case 0x92E1C5D2U /* Enter              */: return RGFW_Return;                /* 0x001C */
+		case 0xE058958CU /* ControlLeft        */: return RGFW_ControlL;         /* 0x001D */
+		case 0x2C595B41U /* KeyA               */: return RGFW_a;                    /* 0x001E */
+		case 0x2C595B53U /* KeyS               */: return RGFW_s;                    /* 0x001F */
+		case 0x2C595B44U /* KeyD               */: return RGFW_d;                    /* 0x0020 */
+		case 0x2C595B46U /* KeyF               */: return RGFW_f;                    /* 0x0021 */
+		case 0x2C595B47U /* KeyG               */: return RGFW_g;                    /* 0x0022 */
+		case 0x2C595B48U /* KeyH               */: return RGFW_h;                    /* 0x0023 */
+		case 0x2C595B4AU /* KeyJ               */: return RGFW_j;                    /* 0x0024 */
+		case 0x2C595B4BU /* KeyK               */: return RGFW_k;                    /* 0x0025 */
+		case 0x2C595B4CU /* KeyL               */: return RGFW_l;                    /* 0x0026 */
+		case 0x2707219EU /* Semicolon          */: return RGFW_Semicolon;            /* 0x0027 */
+		case 0x92E0B58DU /* Quote              */: return RGFW_Apostrophe;                /* 0x0028 */
+		case 0x36BF358DU /* Backquote          */: return RGFW_Backtick;            /* 0x0029 */
+		case 0x26B1958CU /* ShiftLeft          */: return RGFW_ShiftL;           /* 0x002A */
+		case 0x36BF2438U /* Backslash          */: return RGFW_BackSlash;            /* 0x002B */
+		case 0x2C595B5AU /* KeyZ               */: return RGFW_z;                    /* 0x002C */
+		case 0x2C595B58U /* KeyX               */: return RGFW_x;                    /* 0x002D */
+		case 0x2C595B43U /* KeyC               */: return RGFW_c;                    /* 0x002E */
+		case 0x2C595B56U /* KeyV               */: return RGFW_v;                    /* 0x002F */
+		case 0x2C595B42U /* KeyB               */: return RGFW_b;                    /* 0x0030 */
+		case 0x2C595B4EU /* KeyN               */: return RGFW_n;                    /* 0x0031 */
+		case 0x2C595B4DU /* KeyM               */: return RGFW_m;                    /* 0x0032 */
+		case 0x92E1A1C1U /* Comma              */: return RGFW_Comma;                /* 0x0033 */
+		case 0x672FFAD4U /* Period             */: return RGFW_Period;               /* 0x0034 */
+		case 0x92E0A438U /* Slash              */: return RGFW_Slash;                /* 0x0035 */
+		case 0xC5A6BF7CU /* ShiftRight         */: return RGFW_ShiftR;
+		case 0x5D64DA91U /* NumpadMultiply     */: return RGFW_Multiply;
+		case 0xC914958CU /* AltLeft            */: return RGFW_AltL;             /* 0x0038 */
+		case 0x92E09CB5U /* Space              */: return RGFW_Space;                /* 0x0039 */
+		case 0xB8FAE73BU /* CapsLock           */: return RGFW_CapsLock;            /* 0x003A */
+		case 0x7174B789U /* F1                 */: return RGFW_F1;                   /* 0x003B */
+		case 0x7174B78AU /* F2                 */: return RGFW_F2;                   /* 0x003C */
+		case 0x7174B78BU /* F3                 */: return RGFW_F3;                   /* 0x003D */
+		case 0x7174B78CU /* F4                 */: return RGFW_F4;                   /* 0x003E */
+		case 0x7174B78DU /* F5                 */: return RGFW_F5;                   /* 0x003F */
+		case 0x7174B78EU /* F6                 */: return RGFW_F6;                   /* 0x0040 */
+		case 0x7174B78FU /* F7                 */: return RGFW_F7;                   /* 0x0041 */
+		case 0x7174B780U /* F8                 */: return RGFW_F8;                   /* 0x0042 */
+		case 0x7174B781U /* F9                 */: return RGFW_F9;                   /* 0x0043 */
+		case 0x7B8E57B0U /* F10                */: return RGFW_F10;                  /* 0x0044 */
+		case 0xC925FCDFU /* Numpad7            */: return RGFW_Multiply;             /* 0x0047 */
+		case 0xC925FCD0U /* Numpad8            */: return RGFW_KP_8;             /* 0x0048 */
+		case 0xC925FCD1U /* Numpad9            */: return RGFW_KP_9;             /* 0x0049 */
+		case 0x5EA3E8A4U /* NumpadSubtract     */: return RGFW_Minus;      /* 0x004A */
+		case 0xC925FCDCU /* Numpad4            */: return RGFW_KP_4;             /* 0x004B */
+		case 0xC925FCDDU /* Numpad5            */: return RGFW_KP_5;             /* 0x004C */
+		case 0xC925FCDEU /* Numpad6            */: return RGFW_KP_6;             /* 0x004D */
+		case 0xC925FCD9U /* Numpad1            */: return RGFW_KP_1;             /* 0x004F */
+		case 0xC925FCDAU /* Numpad2            */: return RGFW_KP_2;             /* 0x0050 */
+		case 0xC925FCDBU /* Numpad3            */: return RGFW_KP_3;             /* 0x0051 */
+		case 0xC925FCD8U /* Numpad0            */: return RGFW_KP_0;             /* 0x0052 */
+		case 0x95852DACU /* NumpadDecimal      */: return RGFW_KP_Period;       /* 0x0053 */
+		case 0x7B8E57B1U /* F11                */: return RGFW_F11;                  /* 0x0057 */
+		case 0x7B8E57B2U /* F12                */: return RGFW_F12;                  /* 0x0058 */
+		case 0x7393FBACU /* NumpadEqual        */: return RGFW_KP_Return;
+		case 0xB88EBF7CU /* AltRight           */: return RGFW_AltR;            /* 0xE038 */
+		case 0xC925873BU /* NumLock            */: return RGFW_Numlock;             /* 0xE045 */
+		case 0x2C595F45U /* Home               */: return RGFW_Home;                 /* 0xE047 */
+		case 0xC91BB690U /* ArrowUp            */: return RGFW_Up;             /* 0xE048 */
+		case 0x672F9210U /* PageUp             */: return RGFW_PageUp;              /* 0xE049 */
+		case 0x3799258CU /* ArrowLeft          */: return RGFW_Left;           /* 0xE04B */
+		case 0x4CE33F7CU /* ArrowRight         */: return RGFW_Right;          /* 0xE04D */
+		case 0x7B8E55DCU /* End                */: return RGFW_End;                  /* 0xE04F */
+		case 0x3799379EU /* ArrowDown          */: return RGFW_Down;           /* 0xE050 */
+		case 0xBA90179EU /* PageDown           */: return RGFW_PageDown;            /* 0xE051 */
+		case 0x6723CB2CU /* Insert             */: return RGFW_Insert;               /* 0xE052 */
+		case 0x6725C50DU /* Delete             */: return RGFW_Delete;               /* 0xE053 */
+		case 0x6723658CU /* OSLeft             */: return RGFW_SuperL;              /* 0xE05B */
+		case 0x39643F7CU /* MetaRight          */: return RGFW_SuperR;           /* 0xE05C */
+	}
+
+	return 0;
+}
+
 void EMSCRIPTEN_KEEPALIVE RGFW_handleKeyEvent(char* key, char* code, b8 press) {
 	const char* iCode = code;
 	
-	unsigned int hash = 0;
+	u32 hash = 0;
 	while(*iCode) hash = ((hash ^ 0x7E057D79U) << 3) ^ (unsigned int)*iCode++;
 	
-	u32 physicalKey = 0; 
-	switch(hash) {             /* 0x0000 */
-		case 0x67243A2DU /* Escape             */: physicalKey = RGFW_Escape;               /* 0x0001 */
-		case 0x67251058U /* Digit0             */: physicalKey = RGFW_0;                    /* 0x0002 */
-		case 0x67251059U /* Digit1             */: physicalKey = RGFW_1;                    /* 0x0003 */
-		case 0x6725105AU /* Digit2             */: physicalKey = RGFW_2;                    /* 0x0004 */
-		case 0x6725105BU /* Digit3             */: physicalKey = RGFW_3;                    /* 0x0005 */
-		case 0x6725105CU /* Digit4             */: physicalKey = RGFW_4;                    /* 0x0006 */
-		case 0x6725105DU /* Digit5             */: physicalKey = RGFW_5;                    /* 0x0007 */
-		case 0x6725105EU /* Digit6             */: physicalKey = RGFW_6;                    /* 0x0008 */
-		case 0x6725105FU /* Digit7             */: physicalKey = RGFW_7;                    /* 0x0009 */
-		case 0x67251050U /* Digit8             */: physicalKey = RGFW_8;                    /* 0x000A */
-		case 0x67251051U /* Digit9             */: physicalKey = RGFW_9;                    /* 0x000B */
-		case 0x92E14DD3U /* Minus              */: physicalKey = RGFW_Minus;                /* 0x000C */
-		case 0x92E1FBACU /* Equal              */: physicalKey = RGFW_Equals;                /* 0x000D */
-		case 0x36BF1CB5U /* Backspace          */: physicalKey = RGFW_BackSpace;            /* 0x000E */
-		case 0x7B8E51E2U /* Tab                */: physicalKey = RGFW_Tab;                  /* 0x000F */
-		case 0x2C595B51U /* KeyQ               */: physicalKey = RGFW_q;                    /* 0x0010 */
-		case 0x2C595B57U /* KeyW               */: physicalKey = RGFW_w;                    /* 0x0011 */
-		case 0x2C595B45U /* KeyE               */: physicalKey = RGFW_e;                    /* 0x0012 */
-		case 0x2C595B52U /* KeyR               */: physicalKey = RGFW_r;                    /* 0x0013 */
-		case 0x2C595B54U /* KeyT               */: physicalKey = RGFW_t;                    /* 0x0014 */
-		case 0x2C595B59U /* KeyY               */: physicalKey = RGFW_y;                    /* 0x0015 */
-		case 0x2C595B55U /* KeyU               */: physicalKey = RGFW_u;                    /* 0x0016 */
-		case 0x2C595B4FU /* KeyO               */: physicalKey = RGFW_o;                    /* 0x0018 */
-		case 0x2C595B50U /* KeyP               */: physicalKey = RGFW_p;                    /* 0x0019 */
-		case 0x45D8158CU /* BracketLeft        */: physicalKey = RGFW_CloseBracket;         /* 0x001A */
-		case 0xDEEABF7CU /* BracketRight       */: physicalKey = RGFW_Bracket;        /* 0x001B */
-		case 0x92E1C5D2U /* Enter              */: physicalKey = RGFW_Return;                /* 0x001C */
-		case 0xE058958CU /* ControlLeft        */: physicalKey = RGFW_ControlL;         /* 0x001D */
-		case 0x2C595B41U /* KeyA               */: physicalKey = RGFW_a;                    /* 0x001E */
-		case 0x2C595B53U /* KeyS               */: physicalKey = RGFW_s;                    /* 0x001F */
-		case 0x2C595B44U /* KeyD               */: physicalKey = RGFW_d;                    /* 0x0020 */
-		case 0x2C595B46U /* KeyF               */: physicalKey = RGFW_f;                    /* 0x0021 */
-		case 0x2C595B47U /* KeyG               */: physicalKey = RGFW_g;                    /* 0x0022 */
-		case 0x2C595B48U /* KeyH               */: physicalKey = RGFW_h;                    /* 0x0023 */
-		case 0x2C595B4AU /* KeyJ               */: physicalKey = RGFW_j;                    /* 0x0024 */
-		case 0x2C595B4BU /* KeyK               */: physicalKey = RGFW_k;                    /* 0x0025 */
-		case 0x2C595B4CU /* KeyL               */: physicalKey = RGFW_l;                    /* 0x0026 */
-		case 0x2707219EU /* Semicolon          */: physicalKey = RGFW_Semicolon;            /* 0x0027 */
-		case 0x92E0B58DU /* Quote              */: physicalKey = RGFW_Apostrophe;                /* 0x0028 */
-		case 0x36BF358DU /* Backquote          */: physicalKey = RGFW_Backtick;            /* 0x0029 */
-		case 0x26B1958CU /* ShiftLeft          */: physicalKey = RGFW_ShiftL;           /* 0x002A */
-		case 0x36BF2438U /* Backslash          */: physicalKey = RGFW_BackSlash;            /* 0x002B */
-		case 0x2C595B5AU /* KeyZ               */: physicalKey = RGFW_z;                    /* 0x002C */
-		case 0x2C595B58U /* KeyX               */: physicalKey = RGFW_x;                    /* 0x002D */
-		case 0x2C595B43U /* KeyC               */: physicalKey = RGFW_c;                    /* 0x002E */
-		case 0x2C595B56U /* KeyV               */: physicalKey = RGFW_v;                    /* 0x002F */
-		case 0x2C595B42U /* KeyB               */: physicalKey = RGFW_b;                    /* 0x0030 */
-		case 0x2C595B4EU /* KeyN               */: physicalKey = RGFW_n;                    /* 0x0031 */
-		case 0x2C595B4DU /* KeyM               */: physicalKey = RGFW_m;                    /* 0x0032 */
-		case 0x92E1A1C1U /* Comma              */: physicalKey = RGFW_Comma;                /* 0x0033 */
-		case 0x672FFAD4U /* Period             */: physicalKey = RGFW_Period;               /* 0x0034 */
-		case 0x92E0A438U /* Slash              */: physicalKey = RGFW_Slash;                /* 0x0035 */
-		case 0xC5A6BF7CU /* ShiftRight         */: physicalKey = RGFW_ShiftR;
-		case 0x5D64DA91U /* NumpadMultiply     */: physicalKey = RGFW_Multiply;
-		case 0xC914958CU /* AltLeft            */: physicalKey = RGFW_AltL;             /* 0x0038 */
-		case 0x92E09CB5U /* Space              */: physicalKey = RGFW_Space;                /* 0x0039 */
-		case 0xB8FAE73BU /* CapsLock           */: physicalKey = RGFW_CapsLock;            /* 0x003A */
-		case 0x7174B789U /* F1                 */: physicalKey = RGFW_F1;                   /* 0x003B */
-		case 0x7174B78AU /* F2                 */: physicalKey = RGFW_F2;                   /* 0x003C */
-		case 0x7174B78BU /* F3                 */: physicalKey = RGFW_F3;                   /* 0x003D */
-		case 0x7174B78CU /* F4                 */: physicalKey = RGFW_F4;                   /* 0x003E */
-		case 0x7174B78DU /* F5                 */: physicalKey = RGFW_F5;                   /* 0x003F */
-		case 0x7174B78EU /* F6                 */: physicalKey = RGFW_F6;                   /* 0x0040 */
-		case 0x7174B78FU /* F7                 */: physicalKey = RGFW_F7;                   /* 0x0041 */
-		case 0x7174B780U /* F8                 */: physicalKey = RGFW_F8;                   /* 0x0042 */
-		case 0x7174B781U /* F9                 */: physicalKey = RGFW_F9;                   /* 0x0043 */
-		case 0x7B8E57B0U /* F10                */: physicalKey = RGFW_F10;                  /* 0x0044 */
-		case 0xC925FCDFU /* Numpad7            */: physicalKey = RGFW_Multiply;             /* 0x0047 */
-		case 0xC925FCD0U /* Numpad8            */: physicalKey = RGFW_KP_8;             /* 0x0048 */
-		case 0xC925FCD1U /* Numpad9            */: physicalKey = RGFW_KP_9;             /* 0x0049 */
-		case 0x5EA3E8A4U /* NumpadSubtract     */: physicalKey = RGFW_Minus;      /* 0x004A */
-		case 0xC925FCDCU /* Numpad4            */: physicalKey = RGFW_KP_4;             /* 0x004B */
-		case 0xC925FCDDU /* Numpad5            */: physicalKey = RGFW_KP_5;             /* 0x004C */
-		case 0xC925FCDEU /* Numpad6            */: physicalKey = RGFW_KP_6;             /* 0x004D */
-		case 0xC925FCD9U /* Numpad1            */: physicalKey = RGFW_KP_1;             /* 0x004F */
-		case 0xC925FCDAU /* Numpad2            */: physicalKey = RGFW_KP_2;             /* 0x0050 */
-		case 0xC925FCDBU /* Numpad3            */: physicalKey = RGFW_KP_3;             /* 0x0051 */
-		case 0xC925FCD8U /* Numpad0            */: physicalKey = RGFW_KP_0;             /* 0x0052 */
-		case 0x95852DACU /* NumpadDecimal      */: physicalKey = RGFW_KP_Period;       /* 0x0053 */
-		case 0x7B8E57B1U /* F11                */: physicalKey = RGFW_F11;                  /* 0x0057 */
-		case 0x7B8E57B2U /* F12                */: physicalKey = RGFW_F12;                  /* 0x0058 */
-		case 0x7393FBACU /* NumpadEqual        */: physicalKey = RGFW_KP_Return;
-		case 0xB88EBF7CU /* AltRight           */: physicalKey = RGFW_AltR;            /* 0xE038 */
-		case 0xC925873BU /* NumLock            */: physicalKey = RGFW_Numlock;             /* 0xE045 */
-		case 0x2C595F45U /* Home               */: physicalKey = RGFW_Home;                 /* 0xE047 */
-		case 0xC91BB690U /* ArrowUp            */: physicalKey = RGFW_Up;             /* 0xE048 */
-		case 0x672F9210U /* PageUp             */: physicalKey = RGFW_PageUp;              /* 0xE049 */
-		case 0x3799258CU /* ArrowLeft          */: physicalKey = RGFW_Left;           /* 0xE04B */
-		case 0x4CE33F7CU /* ArrowRight         */: physicalKey = RGFW_Right;          /* 0xE04D */
-		case 0x7B8E55DCU /* End                */: physicalKey = RGFW_End;                  /* 0xE04F */
-		case 0x3799379EU /* ArrowDown          */: physicalKey = RGFW_Down;           /* 0xE050 */
-		case 0xBA90179EU /* PageDown           */: physicalKey = RGFW_PageDown;            /* 0xE051 */
-		case 0x6723CB2CU /* Insert             */: physicalKey = RGFW_Insert;               /* 0xE052 */
-		case 0x6725C50DU /* Delete             */: physicalKey = RGFW_Delete;               /* 0xE053 */
-		case 0x6723658CU /* OSLeft             */: physicalKey = RGFW_SuperL;              /* 0xE05B */
-		case 0x39643F7CU /* MetaRight          */: physicalKey = RGFW_SuperR;           /* 0xE05C */
-	}
-
-	u8 keyCode = RGFW_apiMappedToRGFW((u8)(*((u32*)key)));
+	u32 physicalKey = RGFW_webasmPhysicalToRGFW(hash); 
+	u8 mappedKey = RGFW_apiMappedToRGFW((u8)(*((u32*)key)));
 
 	RGFW_events[RGFW_eventLen].type = press ? RGFW_keyPressed : RGFW_keyReleased;
 	memcpy(RGFW_events[RGFW_eventLen].keyName, key, 16);
 	RGFW_events[RGFW_eventLen].physicalKey = physicalKey;
-	RGFW_events[RGFW_eventLen].mappedKey = keyCode;
+	RGFW_events[RGFW_eventLen].mappedKey = mappedKey;
 	RGFW_events[RGFW_eventLen].lockState = 0;
 	RGFW_eventLen++;
 
-	RGFW_keyboard[keyCode].prev = RGFW_keyboard[keyCode].current;
-	RGFW_keyboard[keyCode].current = 0;
+	RGFW_keyboard[physicalKey].prev = RGFW_keyboard[physicalKey].current;
+	RGFW_keyboard[physicalKey].current = 0;
 	
-	RGFW_keyCallback(RGFW_root, RGFW_events[RGFW_eventLen].physicalKey, RGFW_events[RGFW_eventLen].mappedKey, RGFW_events[RGFW_eventLen].keyName, 0, press);
+	RGFW_keyCallback(RGFW_root, physicalKey, mappedKey, RGFW_events[RGFW_eventLen].keyName, 0, press);
 
 	free(key); 
 	free(code);

--- a/RGFW.h
+++ b/RGFW.h
@@ -1087,7 +1087,64 @@ RGFWDEF void RGFW_sleep(u64 milisecond); /*!< sleep for a set time */
 
 typedef RGFW_ENUM(u8, RGFW_Key) {
 	RGFW_KEY_NULL = 0,
-	RGFW_Escape,
+	RGFW_Escape = '\033',
+	RGFW_Backtick = '`',
+	RGFW_0 = '0',
+	RGFW_1 = '1',
+	RGFW_2 = '2',
+	RGFW_3 = '3',
+	RGFW_4 = '4',
+	RGFW_5 = '5',
+	RGFW_6 = '6',
+	RGFW_7 = '7',
+	RGFW_8 = '8',
+	RGFW_9 = '9',
+
+	RGFW_Minus = '-',
+	RGFW_Equals = '=',
+	RGFW_BackSpace = '\b',
+	RGFW_Tab = '\t',
+	RGFW_Space = ' ',
+
+	RGFW_a = 'a',
+	RGFW_b = 'b',
+	RGFW_c = 'c',
+	RGFW_d = 'd',
+	RGFW_e = 'e',
+	RGFW_f = 'f',
+	RGFW_g = 'g',
+	RGFW_h = 'h',
+	RGFW_i = 'i',
+	RGFW_j = 'j',
+	RGFW_k = 'k',
+	RGFW_l = 'l',
+	RGFW_m = 'm',
+	RGFW_n = 'n',
+	RGFW_o = 'o',
+	RGFW_p = 'p',
+	RGFW_q = 'q',
+	RGFW_r = 'r',
+	RGFW_s = 's',
+	RGFW_t = 't',
+	RGFW_u = 'u',
+	RGFW_v = 'v',
+	RGFW_w = 'w',
+	RGFW_x = 'x',
+	RGFW_y = 'y',
+	RGFW_z = 'z',
+
+	RGFW_Period = '.',
+	RGFW_Comma = ',',
+	RGFW_Slash = '/',
+	RGFW_Bracket = '{',
+	RGFW_CloseBracket = '}',
+	RGFW_Semicolon = ';',
+	RGFW_Apostrophe = '\'',
+	RGFW_BackSlash = '\\',
+	RGFW_Return = '\n',
+	
+	RGFW_Delete = '\177', /* 127 */
+
 	RGFW_F1,
 	RGFW_F2,
 	RGFW_F3,
@@ -1101,23 +1158,6 @@ typedef RGFW_ENUM(u8, RGFW_Key) {
 	RGFW_F11,
 	RGFW_F12,
 
-	RGFW_Backtick,
-
-	RGFW_0,
-	RGFW_1,
-	RGFW_2,
-	RGFW_3,
-	RGFW_4,
-	RGFW_5,
-	RGFW_6,
-	RGFW_7,
-	RGFW_8,
-	RGFW_9,
-
-	RGFW_Minus,
-	RGFW_Equals,
-	RGFW_BackSpace,
-	RGFW_Tab,
 	RGFW_CapsLock,
 	RGFW_ShiftL,
 	RGFW_ControlL,
@@ -1127,51 +1167,11 @@ typedef RGFW_ENUM(u8, RGFW_Key) {
 	RGFW_ControlR,
 	RGFW_AltR,
 	RGFW_SuperR,
-	RGFW_Space,
-
-	RGFW_a,
-	RGFW_b,
-	RGFW_c,
-	RGFW_d,
-	RGFW_e,
-	RGFW_f,
-	RGFW_g,
-	RGFW_h,
-	RGFW_i,
-	RGFW_j,
-	RGFW_k,
-	RGFW_l,
-	RGFW_m,
-	RGFW_n,
-	RGFW_o,
-	RGFW_p,
-	RGFW_q,
-	RGFW_r,
-	RGFW_s,
-	RGFW_t,
-	RGFW_u,
-	RGFW_v,
-	RGFW_w,
-	RGFW_x,
-	RGFW_y,
-	RGFW_z,
-
-	RGFW_Period,
-	RGFW_Comma,
-	RGFW_Slash,
-	RGFW_Bracket,
-	RGFW_CloseBracket,
-	RGFW_Semicolon,
-	RGFW_Return,
-	RGFW_Quote,
-	RGFW_BackSlash,
-
 	RGFW_Up,
 	RGFW_Down,
 	RGFW_Left,
 	RGFW_Right,
 
-	RGFW_Delete,
 	RGFW_Insert,
 	RGFW_End,
 	RGFW_Home,
@@ -1182,10 +1182,10 @@ typedef RGFW_ENUM(u8, RGFW_Key) {
 	RGFW_KP_Slash,
 	RGFW_Multiply,
 	RGFW_KP_Minus,
-	RGFW_KP_1,
-	RGFW_KP_2,
-	RGFW_KP_3,
-	RGFW_KP_4,
+	RGFW_KP_1, 
+	RGFW_KP_2, 
+	RGFW_KP_3, 
+	RGFW_KP_4, 
 	RGFW_KP_5,
 	RGFW_KP_6,
 	RGFW_KP_7,
@@ -1319,7 +1319,7 @@ void RGFW_init_keys(void) {
 	RGFW_MAP [RGFW_OS_BASED_VALUE(34, 0x01A, 33, DOM_VK_OPEN_BRACKET, KEY_LEFTBRACE)] = RGFW_Bracket      			RGFW_NEXT
 	RGFW_MAP [RGFW_OS_BASED_VALUE(35, 0x01B, 30, DOM_VK_CLOSE_BRACKET, KEY_RIGHTBRACE)] = RGFW_CloseBracket             RGFW_NEXT
 	RGFW_MAP [RGFW_OS_BASED_VALUE(47, 0x027, 41, DOM_VK_SEMICOLON, KEY_SEMICOLON)] = RGFW_Semicolon                 RGFW_NEXT
-	RGFW_MAP [RGFW_OS_BASED_VALUE(48, 0x028, 39, DOM_VK_QUOTE, KEY_APOSTROPHE)] = RGFW_Quote                 			RGFW_NEXT
+	RGFW_MAP [RGFW_OS_BASED_VALUE(48, 0x028, 39, DOM_VK_QUOTE, KEY_APOSTROPHE)] = RGFW_Apostrophe                 			RGFW_NEXT
 	RGFW_MAP [RGFW_OS_BASED_VALUE(51, 0x02B, 42, DOM_VK_BACK_SLASH, KEY_BACKSLASH)] = RGFW_BackSlash,
 	
 	RGFW_MAP [RGFW_OS_BASED_VALUE(36, 0x01C, 36, DOM_VK_RETURN, KEY_ENTER)] = RGFW_Return              RGFW_NEXT
@@ -5239,7 +5239,70 @@ static HMODULE wglinstance = NULL;
 	}
 
 	u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
-		return RGFW_apiPhysicalToRGFW(MapVirtualKeyW((u32)mappedKey, MAPVK_VSC_TO_VK));
+		switch (mappedKey) {
+			case VK_CONTROL: return RGFW_ControlL;
+			case VK_CAPITAL: return RGFW_CapsLock;
+			case VK_OEM_3: return '`';
+			case VK_SHIFT: return RGFW_ShiftL;
+			case VK_RIGHT: return RGFW_Right;
+			case VK_LEFT: return RGFW_Left;
+			case VK_DOWN: return RGFW_Down;
+			case VK_UP: return RGFW_Up;
+			case VK_RETURN: return '\n';
+			case 190: return RGFW_Period;
+			case 188: return RGFW_Comma;
+			case 191: return RGFW_Slash;
+			case 219: return RGFW_Bracket;
+			case 221: return RGFW_CloseBracket; 
+			case 186: return RGFW_Semicolon;  
+			case 222: return RGFW_Apostrophe;  
+			case 322: return RGFW_BackSlash;
+			case 0x2E: return RGFW_Delete; 
+			case 0x90: return RGFW_Numlock;
+			case 0x6F: return RGFW_KP_Slash;
+			case 0x6A: return RGFW_Multiply;  
+			case 0x6D: return RGFW_KP_Minus;  
+			case 0x61: return RGFW_KP_1;
+			case 0x62: return RGFW_KP_2;
+			case 0x63: return RGFW_KP_3;
+			case 0x64: return RGFW_KP_4;
+			case 0x65: return RGFW_KP_5;
+			case 0x66: return RGFW_KP_6;
+			case 0x67: return RGFW_KP_7;
+			case 0x68: return RGFW_KP_8;
+			case 0x69: return RGFW_KP_9;
+			case 0x60: return RGFW_KP_0;
+			case 0x6E: return RGFW_KP_Period;  
+			case 0x92: return RGFW_KP_Return;
+			case 189: return RGFW_Minus;  
+			case 187: return RGFW_Equals;
+			case 0x12: return RGFW_AltL; 
+			case 0x5B: return RGFW_SuperL;
+			case 0x70: return RGFW_F1;  
+			case 0x71: return RGFW_F2;  
+			case 0x72: return RGFW_F3;  
+			case 0x73: return RGFW_F4;  
+			case 0x74: return RGFW_F5;  
+			case 0x75: return RGFW_F6;  
+			case 0x76: return RGFW_F7;  
+			case 0x77: return RGFW_F8;
+			case 0x78: return RGFW_F9;
+			case 0x79: return RGFW_F10;
+			case 0x7A: return RGFW_F11;
+			case 0x7B: return RGFW_F12;
+			case 0x2D: return RGFW_Insert;
+			case 0x23: return RGFW_End;
+			case 336: return RGFW_PageUp;
+			case 325: return RGFW_PageDown;
+			case 0x24: return RGFW_Home;
+			default: break;
+		}
+		printf("%i\n", mappedKey);
+
+		u8 ch = mappedKey;
+		CharLowerBuffA(&ch, 1);
+
+		return ch;
 	}
 	
 	#ifndef RGFW_NO_DPI
@@ -5990,7 +6053,6 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 				}
 
 				win->event.mappedKey = RGFW_apiMappedToRGFW((u32)msg.wParam);
-				
 				RGFW_keyboard[win->event.physicalKey].prev = RGFW_isPressed(win, win->event.physicalKey);
 
 				static char keyName[16];

--- a/RGFW.h
+++ b/RGFW.h
@@ -1413,11 +1413,89 @@ u32 RGFW_apiPhysicalToRGFW(u32 keycode) {
 	return RGFW_keycodes[keycode];
 }
 
-#ifndef RGFW_WINDOWS
-u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
-	return 0;
-}
+#ifdef RGFW_WINDOWS
+u32 CharLowerBuffA(char*, u32);
 #endif
+
+u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
+	switch (mappedKey) {
+		#ifdef RGFW_WINDOWS
+		case 0xC0: return '`';
+		case 189: return '-';  
+		case 187: return '=';
+		case 190: return RGFW_Period;
+		case 188: return RGFW_Comma;
+		case 191: return RGFW_Slash;
+		case 219: return RGFW_Bracket;
+		case 221: return RGFW_CloseBracket; 
+		case 186: return RGFW_Semicolon;  
+		case 222: return RGFW_Apostrophe;  
+		case 322: return RGFW_BackSlash;
+		#else
+		case RGFW_OS_BASED_VALUE(226, 0, 0, 0, 0): return RGFW_ShiftR;
+		case RGFW_OS_BASED_VALUE(228, 0, 0, 0, 0): return RGFW_ControlR;
+		case RGFW_OS_BASED_VALUE(234, 0, 0, 0, 0): return RGFW_AltR;
+		#endif
+
+		#ifndef RGFW_X11
+		case RGFW_OS_BASED_VALUE(0, 0x2D, 0, 0, 0): return RGFW_Insert;
+		#endif
+
+		case RGFW_OS_BASED_VALUE(253, 0x5B, 0, 0, 0): return RGFW_SuperL;
+		case RGFW_OS_BASED_VALUE(236, 0, 0, 0, 0): return RGFW_SuperR;
+		case RGFW_OS_BASED_VALUE(13, 0x0D, 0, 0, 0): return '\n';
+		case RGFW_OS_BASED_VALUE(227, 0x11, 0, 0, 0): return RGFW_ControlL;
+		case RGFW_OS_BASED_VALUE(229, 0x14, 0, 0, 0): return RGFW_CapsLock;
+		case RGFW_OS_BASED_VALUE(225, 0x10, 0, 0, 0): return RGFW_ShiftL;
+		case RGFW_OS_BASED_VALUE(83, 0x27, 0, 0, 0): return RGFW_Right;
+		case RGFW_OS_BASED_VALUE(81, 0x25, 0, 0, 0): return RGFW_Left;
+		case RGFW_OS_BASED_VALUE(82, 0x26, 0, 0, 0): return RGFW_Up;
+		case RGFW_OS_BASED_VALUE(84, 0x28, 0, 0, 0): return RGFW_Down;
+		case RGFW_OS_BASED_VALUE(127, 0x90, 0, 0, 0): return RGFW_Numlock;
+		case RGFW_OS_BASED_VALUE(156, 0x61, 0, 0, 0): 
+			printf("h\n");
+			return RGFW_KP_1;	
+		case RGFW_OS_BASED_VALUE(153, 0x62, 0, 0, 0): return RGFW_KP_2;
+		case RGFW_OS_BASED_VALUE(155, 0x63, 0, 0, 0): return RGFW_KP_3;
+		case RGFW_OS_BASED_VALUE(150, 0x64, 0, 0, 0): return RGFW_KP_4;
+		case RGFW_OS_BASED_VALUE(157, 0x65, 0, 0, 0): return RGFW_KP_5;
+		case RGFW_OS_BASED_VALUE(152, 0x66, 0, 0, 0): return RGFW_KP_6;
+		case RGFW_OS_BASED_VALUE(149, 0x67, 0, 0, 0): return RGFW_KP_7;
+		case RGFW_OS_BASED_VALUE(151, 0x68, 0, 0, 0): return RGFW_KP_8;
+		case RGFW_OS_BASED_VALUE(154, 0x69, 0, 0, 0): return RGFW_KP_9;
+		case RGFW_OS_BASED_VALUE(158, 0x60, 0, 0, 0): return RGFW_KP_0;
+		case RGFW_OS_BASED_VALUE(255, 0x2E, 0, 0, 0): return RGFW_Delete;
+		case RGFW_OS_BASED_VALUE(190, 0x70, 0, 0, 0): return RGFW_F1;  
+		case RGFW_OS_BASED_VALUE(191, 0x71, 0, 0, 0): return RGFW_F2;  
+		case RGFW_OS_BASED_VALUE(192, 0x72, 0, 0, 0): return RGFW_F3;  
+		case RGFW_OS_BASED_VALUE(193, 0x73, 0, 0, 0): return RGFW_F4;  
+		case RGFW_OS_BASED_VALUE(194, 0x74, 0, 0, 0): return RGFW_F5;  
+		case RGFW_OS_BASED_VALUE(195, 0x75, 0, 0, 0): return RGFW_F6;  
+		case RGFW_OS_BASED_VALUE(196, 0x76, 0, 0, 0): return RGFW_F7;  
+		case RGFW_OS_BASED_VALUE(197, 0x77, 0, 0, 0): return RGFW_F8;
+		case RGFW_OS_BASED_VALUE(198, 0x78, 0, 0, 0): return RGFW_F9;
+		case RGFW_OS_BASED_VALUE(199, 0x79, 0, 0, 0): return RGFW_F10;
+		case RGFW_OS_BASED_VALUE(200, 0x7A, 0, 0, 0): return RGFW_F11;
+		case RGFW_OS_BASED_VALUE(201, 0x7B, 0, 0, 0): return RGFW_F12;
+		case RGFW_OS_BASED_VALUE(87, 0x23, 0, 0, 0): return RGFW_End;
+		case RGFW_OS_BASED_VALUE(85, 336, 0, 0, 0): return RGFW_PageUp;
+		case RGFW_OS_BASED_VALUE(86, 325, 0, 0, 0): return RGFW_PageDown;
+		case RGFW_OS_BASED_VALUE(80, 0x24, 0, 0, 0): return RGFW_Home;
+		case RGFW_OS_BASED_VALUE(175, 0x6F, 0, 0, 0): return RGFW_KP_Slash;
+		case RGFW_OS_BASED_VALUE(170, 0x6A, 0, 0, 0): return RGFW_Multiply;  
+		case RGFW_OS_BASED_VALUE(173, 0x6D, 0, 0, 0): return RGFW_KP_Minus;  
+		case RGFW_OS_BASED_VALUE(159, 0x6E, 0, 0, 0): return RGFW_KP_Period;  
+		case RGFW_OS_BASED_VALUE(141, 0x92, 0, 0, 0): return RGFW_KP_Return;
+		case RGFW_OS_BASED_VALUE(233, 0x12, 0, 0, 0): return RGFW_AltL; 
+		default: break;
+	}
+
+	#ifdef RGFW_WINDOWS
+	u8 ch = mappedKey;
+	CharLowerBuffA(&ch, 1);
+	#endif
+	return mappedKey;
+}
 
 RGFWDEF void RGFW_resetKey(void);
 void RGFW_resetKey(void) {
@@ -2843,16 +2921,20 @@ Start of Linux / Unix defines
 					XEvent NE;
 					XPeekEvent((Display*) win->src.display, &NE);
 
-					if (E.xkey.time == NE.xkey.time && E.xkey.physicalKey == NE.xkey.keycode) /* check if the current and next are both the same*/
+					if (E.xkey.time == NE.xkey.time && E.xkey.keycode == NE.xkey.keycode) /* check if the current and next are both the same*/
 						win->event.repeat = RGFW_TRUE;
 				}
 
 				/* set event key data */
-				KeySym sym = (KeySym)XkbKeycodeToKeysym((Display*) win->src.display, E.xkey.physicalKey, 0, E.xkey.state & ShiftMask ? 1 : 0);
 				win->event.physicalKey = RGFW_apiPhysicalToRGFW(E.xkey.keycode);
 
-				win->event.physicalKey = RGFW_apiPhysicalToRGFW(mappedKey);
+				KeySym mappedKey = (KeySym)XkbKeycodeToKeysym((Display*) win->src.display, E.xkey.keycode, 0, 0);
+				if (mappedKey == XK_Insert)
+					mappedKey = RGFW_Insert;
+				else
+					win->event.mappedKey = RGFW_apiMappedToRGFW((u8)mappedKey);
 				
+				KeySym sym = (KeySym)XkbKeycodeToKeysym((Display*) win->src.display, E.xkey.keycode, 0, E.xkey.state & ShiftMask ? 1 : 0);
 				char* str = (char*)XKeysymToString(sym);
 				if (str != NULL)
 					strncpy(win->event.keyName, str, 16);
@@ -5238,73 +5320,6 @@ static HMODULE wglinstance = NULL;
 		}
 	}
 
-	u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
-		switch (mappedKey) {
-			case VK_CONTROL: return RGFW_ControlL;
-			case VK_CAPITAL: return RGFW_CapsLock;
-			case VK_OEM_3: return '`';
-			case VK_SHIFT: return RGFW_ShiftL;
-			case VK_RIGHT: return RGFW_Right;
-			case VK_LEFT: return RGFW_Left;
-			case VK_DOWN: return RGFW_Down;
-			case VK_UP: return RGFW_Up;
-			case VK_RETURN: return '\n';
-			case 190: return RGFW_Period;
-			case 188: return RGFW_Comma;
-			case 191: return RGFW_Slash;
-			case 219: return RGFW_Bracket;
-			case 221: return RGFW_CloseBracket; 
-			case 186: return RGFW_Semicolon;  
-			case 222: return RGFW_Apostrophe;  
-			case 322: return RGFW_BackSlash;
-			case 0x2E: return RGFW_Delete; 
-			case 0x90: return RGFW_Numlock;
-			case 0x6F: return RGFW_KP_Slash;
-			case 0x6A: return RGFW_Multiply;  
-			case 0x6D: return RGFW_KP_Minus;  
-			case 0x61: return RGFW_KP_1;
-			case 0x62: return RGFW_KP_2;
-			case 0x63: return RGFW_KP_3;
-			case 0x64: return RGFW_KP_4;
-			case 0x65: return RGFW_KP_5;
-			case 0x66: return RGFW_KP_6;
-			case 0x67: return RGFW_KP_7;
-			case 0x68: return RGFW_KP_8;
-			case 0x69: return RGFW_KP_9;
-			case 0x60: return RGFW_KP_0;
-			case 0x6E: return RGFW_KP_Period;  
-			case 0x92: return RGFW_KP_Return;
-			case 189: return RGFW_Minus;  
-			case 187: return RGFW_Equals;
-			case 0x12: return RGFW_AltL; 
-			case 0x5B: return RGFW_SuperL;
-			case 0x70: return RGFW_F1;  
-			case 0x71: return RGFW_F2;  
-			case 0x72: return RGFW_F3;  
-			case 0x73: return RGFW_F4;  
-			case 0x74: return RGFW_F5;  
-			case 0x75: return RGFW_F6;  
-			case 0x76: return RGFW_F7;  
-			case 0x77: return RGFW_F8;
-			case 0x78: return RGFW_F9;
-			case 0x79: return RGFW_F10;
-			case 0x7A: return RGFW_F11;
-			case 0x7B: return RGFW_F12;
-			case 0x2D: return RGFW_Insert;
-			case 0x23: return RGFW_End;
-			case 336: return RGFW_PageUp;
-			case 325: return RGFW_PageDown;
-			case 0x24: return RGFW_Home;
-			default: break;
-		}
-		printf("%i\n", mappedKey);
-
-		u8 ch = mappedKey;
-		CharLowerBuffA(&ch, 1);
-
-		return ch;
-	}
-	
 	#ifndef RGFW_NO_DPI
 	static HMODULE RGFW_Shcore_dll = NULL;
 	typedef HRESULT (WINAPI * PFN_GetDpiForMonitor)(HMONITOR,MONITOR_DPI_TYPE,UINT*,UINT*);

--- a/RGFW.h
+++ b/RGFW.h
@@ -1414,12 +1414,7 @@ u32 RGFW_apiPhysicalToRGFW(u32 keycode) {
 }
 
 u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
-	#if defined(RGFW_WAYLAND)
-		#undef RGFW_OS_BASED_VALUE
-		#define RGFW_OS_BASED_VALUE(l, w, m, h, ww) l 
-	#endif
-
-#if !defined(RGFW_MACOS)
+#if !defined(RGFW_MACOS) && !defined(RGFW_WEBASM)
 	switch (mappedKey) {
 		#ifdef RGFW_WINDOWS
 		case 0xC0: return '`';
@@ -1433,68 +1428,63 @@ u32 RGFW_apiMappedToRGFW(u32 mappedKey) {
 		case 186: return ';';  
 		case 222: return '\'';  
 		case 220: return '\\';
-		#else
-		case RGFW_OS_BASED_VALUE(226, 0, 0, 0, 226): return RGFW_ShiftR;
-		case RGFW_OS_BASED_VALUE(228, 0, 0, 0, 228): return RGFW_ControlR;
-		case RGFW_OS_BASED_VALUE(234, 0, 0, 0, 234): return RGFW_AltR;
+		#elif !defined(RGFW_WEBASM)
+		case RGFW_OS_BASED_VALUE(226, 0, 0, 0, 0): return RGFW_ShiftR;
+		case RGFW_OS_BASED_VALUE(228, 0, 0, 0, 0): return RGFW_ControlR;
+		case RGFW_OS_BASED_VALUE(234, 0, 0, 0, 0): return RGFW_AltR;
+		case RGFW_OS_BASED_VALUE(236, 0, 0, 0, 0): return RGFW_SuperR;
 		#endif
 
-		#if !defined(RGFW_X11) && !defined(RGFW_WAYLAND)
+		#ifndef RGFW_X11
 		case RGFW_OS_BASED_VALUE(0, 0x2D, 0, 0, 0): return RGFW_Insert;
 		#endif
 
-		case RGFW_OS_BASED_VALUE(253, 0x5B, 0, 0, 0): return RGFW_SuperL;
-		case RGFW_OS_BASED_VALUE(236, 0, 0, 0, 0): return RGFW_SuperR;
-		case RGFW_OS_BASED_VALUE(13, 0x0D, 0, 0, 0): return '\n';
-		case RGFW_OS_BASED_VALUE(227, 0x11, 0, 0, 0): return RGFW_ControlL;
-		case RGFW_OS_BASED_VALUE(229, 0x14, 0, 0, 0): return RGFW_CapsLock;
-		case RGFW_OS_BASED_VALUE(225, 0x10, 0, 0, 0): return RGFW_ShiftL;
-		case RGFW_OS_BASED_VALUE(83, 0x27, 0, 0, 0): return RGFW_Right;
-		case RGFW_OS_BASED_VALUE(81, 0x25, 0, 0, 0): return RGFW_Left;
-		case RGFW_OS_BASED_VALUE(82, 0x26, 0, 0, 0): return RGFW_Up;
-		case RGFW_OS_BASED_VALUE(84, 0x28, 0, 0, 0): return RGFW_Down;
-		case RGFW_OS_BASED_VALUE(127, 0x90, 0, 0, 0): return RGFW_Numlock;
-		case RGFW_OS_BASED_VALUE(156, 0x61, 0, 0, 0): return RGFW_KP_1;	
-		case RGFW_OS_BASED_VALUE(153, 0x62, 0, 0, 0): return RGFW_KP_2;
-		case RGFW_OS_BASED_VALUE(155, 0x63, 0, 0, 0): return RGFW_KP_3;
-		case RGFW_OS_BASED_VALUE(150, 0x64, 0, 0, 0): return RGFW_KP_4;
-		case RGFW_OS_BASED_VALUE(157, 0x65, 0, 0, 0): return RGFW_KP_5;
-		case RGFW_OS_BASED_VALUE(152, 0x66, 0, 0, 0): return RGFW_KP_6;
-		case RGFW_OS_BASED_VALUE(149, 0x67, 0, 0, 0): return RGFW_KP_7;
-		case RGFW_OS_BASED_VALUE(151, 0x68, 0, 0, 0): return RGFW_KP_8;
-		case RGFW_OS_BASED_VALUE(154, 0x69, 0, 0, 0): return RGFW_KP_9;
-		case RGFW_OS_BASED_VALUE(158, 0x60, 0, 0, 0): return RGFW_KP_0;
-		case RGFW_OS_BASED_VALUE(255, 0x2E, 0, 0, 0): return RGFW_Delete;
-		case RGFW_OS_BASED_VALUE(190, 0x70, 0, 0, 0): return RGFW_F1;  
-		case RGFW_OS_BASED_VALUE(191, 0x71, 0, 0, 0): return RGFW_F2;  
-		case RGFW_OS_BASED_VALUE(192, 0x72, 0, 0, 0): return RGFW_F3;  
-		case RGFW_OS_BASED_VALUE(193, 0x73, 0, 0, 0): return RGFW_F4;  
-		case RGFW_OS_BASED_VALUE(194, 0x74, 0, 0, 0): return RGFW_F5;  
-		case RGFW_OS_BASED_VALUE(195, 0x75, 0, 0, 0): return RGFW_F6;  
-		case RGFW_OS_BASED_VALUE(196, 0x76, 0, 0, 0): return RGFW_F7;  
-		case RGFW_OS_BASED_VALUE(197, 0x77, 0, 0, 0): return RGFW_F8;
-		case RGFW_OS_BASED_VALUE(198, 0x78, 0, 0, 0): return RGFW_F9;
-		case RGFW_OS_BASED_VALUE(199, 0x79, 0, 0, 0): return RGFW_F10;
-		case RGFW_OS_BASED_VALUE(200, 0x7A, 0, 0, 0): return RGFW_F11;
-		case RGFW_OS_BASED_VALUE(201, 0x7B, 0, 0, 0): return RGFW_F12;
-		case RGFW_OS_BASED_VALUE(87, 0x23, 0, 0, 0): return RGFW_End;
-		case RGFW_OS_BASED_VALUE(85, 336, 0, 0, 0): return RGFW_PageUp;
-		case RGFW_OS_BASED_VALUE(86, 325, 0, 0, 0): return RGFW_PageDown;
-		case RGFW_OS_BASED_VALUE(80, 0x24, 0, 0, 0): return RGFW_Home;
-		case RGFW_OS_BASED_VALUE(175, 0x6F, 0, 0, 0): return RGFW_KP_Slash;
-		case RGFW_OS_BASED_VALUE(170, 0x6A, 0, 0, 0): return RGFW_Multiply;  
-		case RGFW_OS_BASED_VALUE(173, 0x6D, 0, 0, 0): return RGFW_KP_Minus;  
-		case RGFW_OS_BASED_VALUE(159, 0x6E, 0, 0, 0): return RGFW_KP_Period;  
-		case RGFW_OS_BASED_VALUE(141, 0x92, 0, 0, 0): return RGFW_KP_Return;
-		case RGFW_OS_BASED_VALUE(233, 0x12, 0, 0, 0): return RGFW_AltL; 
+		case RGFW_OS_BASED_VALUE(253, 0x5B, 0, DOM_VK_WIN, 0): return RGFW_SuperL;
+		case RGFW_OS_BASED_VALUE(13, 0x0D, 0, DOM_VK_RETURN, 0): return '\n';
+		case RGFW_OS_BASED_VALUE(227, 0x11, 0, DOM_VK_CONTROL, 0): return RGFW_ControlL;
+		case RGFW_OS_BASED_VALUE(229, 0x14, 0, DOM_VK_CAPS_LOCK, 0): return RGFW_CapsLock;
+		case RGFW_OS_BASED_VALUE(225, 0x10, 0, DOM_VK_SHIFT, 0): return RGFW_ShiftL;
+		case RGFW_OS_BASED_VALUE(83, 0x27, 0, DOM_VK_RIGHT, 0): return RGFW_Right;
+		case RGFW_OS_BASED_VALUE(81, 0x25, 0, DOM_VK_LEFT, 0): return RGFW_Left;
+		case RGFW_OS_BASED_VALUE(82, 0x26, 0, DOM_VK_UP, 0): return RGFW_Up;
+		case RGFW_OS_BASED_VALUE(84, 0x28, 0, DOM_VK_DOWN, 0): return RGFW_Down;
+		case RGFW_OS_BASED_VALUE(127, 0x90, 0, DOM_VK_NUM_LOCK, 0): return RGFW_Numlock;
+		case RGFW_OS_BASED_VALUE(156, 0x61, 0, DOM_VK_NUMPAD1, 0): return RGFW_KP_1;	
+		case RGFW_OS_BASED_VALUE(153, 0x62, 0, DOM_VK_NUMPAD2, 0): return RGFW_KP_2;
+		case RGFW_OS_BASED_VALUE(155, 0x63, 0, DOM_VK_NUMPAD3, 0): return RGFW_KP_3;
+		case RGFW_OS_BASED_VALUE(150, 0x64, 0, DOM_VK_NUMPAD4, 0): return RGFW_KP_4;
+		case RGFW_OS_BASED_VALUE(157, 0x65, 0, DOM_VK_NUMPAD5, 0): return RGFW_KP_5;
+		case RGFW_OS_BASED_VALUE(152, 0x66, 0, DOM_VK_NUMPAD6, 0): return RGFW_KP_6;
+		case RGFW_OS_BASED_VALUE(149, 0x67, 0, DOM_VK_NUMPAD7, 0): return RGFW_KP_7;
+		case RGFW_OS_BASED_VALUE(151, 0x68, 0, DOM_VK_NUMPAD8, 0): return RGFW_KP_8;
+		case RGFW_OS_BASED_VALUE(154, 0x69, 0, DOM_VK_NUMPAD9, 0): return RGFW_KP_9;
+		case RGFW_OS_BASED_VALUE(158, 0x60, 0, DOM_VK_NUMPAD0, 0): return RGFW_KP_0;
+		case RGFW_OS_BASED_VALUE(255, 0x2E, 0, DOM_VK_DELETE, 0): return RGFW_Delete;
+		case RGFW_OS_BASED_VALUE(190, 0x70, 0, DOM_VK_F1, 0): return RGFW_F1;  
+		case RGFW_OS_BASED_VALUE(191, 0x71, 0, DOM_VK_F2, 0): return RGFW_F2;  
+		case RGFW_OS_BASED_VALUE(192, 0x72, 0, DOM_VK_F3, 0): return RGFW_F3;  
+		case RGFW_OS_BASED_VALUE(193, 0x73, 0, DOM_VK_F4, 0): return RGFW_F4;  
+		case RGFW_OS_BASED_VALUE(194, 0x74, 0, DOM_VK_F5, 0): return RGFW_F5;  
+		case RGFW_OS_BASED_VALUE(195, 0x75, 0, DOM_VK_F6, 0): return RGFW_F6;  
+		case RGFW_OS_BASED_VALUE(196, 0x76, 0, DOM_VK_F7, 0): return RGFW_F7;  
+		case RGFW_OS_BASED_VALUE(197, 0x77, 0, DOM_VK_F8, 0): return RGFW_F8;
+		case RGFW_OS_BASED_VALUE(198, 0x78, 0, DOM_VK_F9, 0): return RGFW_F9;
+		case RGFW_OS_BASED_VALUE(199, 0x79, 0, DOM_VK_F10, 0): return RGFW_F10;
+		case RGFW_OS_BASED_VALUE(200, 0x7A, 0, DOM_VK_F11, 0): return RGFW_F11;
+		case RGFW_OS_BASED_VALUE(201, 0x7B, 0, DOM_VK_F12, 0): return RGFW_F12;
+		case RGFW_OS_BASED_VALUE(87, 0x23, 0, DOM_VK_END, 0): return RGFW_End;
+		case RGFW_OS_BASED_VALUE(85, 336, 0, DOM_VK_PAGE_UP, 0): return RGFW_PageUp;
+		case RGFW_OS_BASED_VALUE(86, 325, 0, DOM_VK_PAGE_DOWN, 0): return RGFW_PageDown;
+		case RGFW_OS_BASED_VALUE(80, 0x24, 0, DOM_VK_HOME, 0): return RGFW_Home;
+		case RGFW_OS_BASED_VALUE(175, 0x6F, 0, DOM_VK_DIVIDE, 0): return RGFW_KP_Slash;
+		case RGFW_OS_BASED_VALUE(170, 0x6A, 0, DOM_VK_MULTIPLY, 0): return RGFW_Multiply;  
+		case RGFW_OS_BASED_VALUE(173, 0x6D, 0,DOM_VK_SUBTRACT0, 0): return RGFW_KP_Minus;  
+		case RGFW_OS_BASED_VALUE(159, 0x6E, 0, DOM_VK_DECIMAL, 0): return RGFW_KP_Period;  
+		case RGFW_OS_BASED_VALUE(141, 0x92, 0, KEY_KPENTER, 0): return RGFW_KP_Return;
+		case RGFW_OS_BASED_VALUE(233, 0x12, 0, DOM_VK_ALT, 0): return RGFW_AltL; 
 		default: break;
 	}
 #endif
-
-	#if defined(RGFW_WAYLAND)
-		#undef RGFW_OS_BASED_VALUE
-		#define RGFW_OS_BASED_VALUE(l, w, m, h, ww) ww 
-	#endif
 
 	if (mappedKey >= 'A' && mappedKey <= 'Z')				
 		mappedKey += 'a' - 'A';
@@ -4535,8 +4525,6 @@ static void keyboard_key (void *data, struct wl_keyboard *keyboard, uint32_t ser
 	char name[16];
 	xkb_keysym_get_name(keysym, name, 16);
 
-	u32 mappedKey = (u8)RGFW_apiMappedToRGFW((u8)keysym);
-
 	u32 RGFW_key = RGFW_apiPhysicalToRGFW(key);
 	RGFW_keyboard[RGFW_key].prev = RGFW_keyboard[RGFW_key].current;
 	RGFW_keyboard[RGFW_key].current = state;
@@ -4549,7 +4537,7 @@ static void keyboard_key (void *data, struct wl_keyboard *keyboard, uint32_t ser
 	
 	RGFW_updateLockState(RGFW_key_win, xkb_keymap_mod_get_index(keymap, "Lock"), xkb_keymap_mod_get_index(keymap, "Mod2"));
 
-	RGFW_keyCallback(RGFW_key_win, RGFW_key, mappedKey, name, RGFW_key_win->event.lockState, state);
+	RGFW_keyCallback(RGFW_key_win, RGFW_key, name, RGFW_key_win->event.lockState, state);
 }
 static void keyboard_modifiers (void *data, struct wl_keyboard *keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group) {
 	RGFW_UNUSED(data); RGFW_UNUSED(keyboard); RGFW_UNUSED(serial); RGFW_UNUSED(time); 
@@ -8516,41 +8504,6 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 RGFW_Event RGFW_events[20];
 size_t RGFW_eventLen = 0;
 
-EM_BOOL Emscripten_on_keydown(int eventType, const EmscriptenKeyboardEvent* e, void* userData) {
-	RGFW_UNUSED(eventType); RGFW_UNUSED(userData);
-	
-	RGFW_events[RGFW_eventLen].type = RGFW_keyPressed;
-	memcpy(RGFW_events[RGFW_eventLen].keyName, e->key, 16);
-	RGFW_events[RGFW_eventLen].mappedKey = RGFW_apiPhysicalToRGFW((u32)mappedKey);
-	RGFW_events[RGFW_eventLen].mappedKey = RGFW_apiPhysicalToRGFW((u32)mappedKey);
-	RGFW_events[RGFW_eventLen].physicalKey = RGFW_apiPhysicalToRGFW(e->keyCode);
-	RGFW_events[RGFW_eventLen].lockState = 0;
-	RGFW_eventLen++;
-
-	RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].prev = RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].current;
-	RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].current = 1;
-	RGFW_keyCallback(RGFW_root, RGFW_apiPhysicalToRGFW(e->keyCode), RGFW_events[RGFW_eventLen].keyName, 0, 1);
-	
-    return EM_TRUE;
-}
-
-EM_BOOL Emscripten_on_keyup(int eventType, const EmscriptenKeyboardEvent* e, void* userData) {
-	RGFW_UNUSED(eventType); RGFW_UNUSED(userData);
-
-	RGFW_events[RGFW_eventLen].type = RGFW_keyReleased;
-	memcpy(RGFW_events[RGFW_eventLen].keyName, e->key, 16);
-	RGFW_events[RGFW_eventLen].physicalKey = RGFW_apiPhysicalToRGFW(e->keyCode);
-	RGFW_events[RGFW_eventLen].lockState = 0;
-	RGFW_eventLen++;
-
-	RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].prev = RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].current;
-	RGFW_keyboard[RGFW_apiPhysicalToRGFW(e->keyCode)].current = 0;
-
-	RGFW_keyCallback(RGFW_root, RGFW_apiPhysicalToRGFW(e->keyCode), RGFW_events[RGFW_eventLen].keyName, 0, 0);
-
-    return EM_TRUE;
-}
-
 EM_BOOL Emscripten_on_resize(int eventType, const EmscriptenUiEvent* e, void* userData) {
 	RGFW_UNUSED(eventType); RGFW_UNUSED(userData);
 
@@ -8579,7 +8532,7 @@ EM_BOOL Emscripten_on_fullscreenchange(int eventType, const EmscriptenFullscreen
 	RGFW_root->r = RGFW_RECT(0, 0, e->screenWidth, e->screenHeight);
 	
 	EM_ASM("Module.canvas.focus();");
-	
+
 	if (fullscreen == RGFW_FALSE) {
 		RGFW_root->r = RGFW_RECT(0, 0, ogRect.w, ogRect.h);
 		// emscripten_request_fullscreen("#canvas", 0);
@@ -8760,6 +8713,130 @@ EM_BOOL Emscripten_on_gamepad(int eventType, const EmscriptenGamepadEvent *gamep
     return 1; // The event was consumed by the callback handler
 }
 
+void EMSCRIPTEN_KEEPALIVE RGFW_handleKeyEvent(char* key, char* code, b8 press) {
+	const char* iCode = code;
+	
+	unsigned int hash = 0;
+	while(*iCode) hash = ((hash ^ 0x7E057D79U) << 3) ^ (unsigned int)*iCode++;
+	
+	u32 physicalKey = 0; 
+	switch(hash) {             /* 0x0000 */
+		case 0x67243A2DU /* Escape             */: physicalKey = RGFW_Escape;               /* 0x0001 */
+		case 0x67251058U /* Digit0             */: physicalKey = RGFW_0;                    /* 0x0002 */
+		case 0x67251059U /* Digit1             */: physicalKey = RGFW_1;                    /* 0x0003 */
+		case 0x6725105AU /* Digit2             */: physicalKey = RGFW_2;                    /* 0x0004 */
+		case 0x6725105BU /* Digit3             */: physicalKey = RGFW_3;                    /* 0x0005 */
+		case 0x6725105CU /* Digit4             */: physicalKey = RGFW_4;                    /* 0x0006 */
+		case 0x6725105DU /* Digit5             */: physicalKey = RGFW_5;                    /* 0x0007 */
+		case 0x6725105EU /* Digit6             */: physicalKey = RGFW_6;                    /* 0x0008 */
+		case 0x6725105FU /* Digit7             */: physicalKey = RGFW_7;                    /* 0x0009 */
+		case 0x67251050U /* Digit8             */: physicalKey = RGFW_8;                    /* 0x000A */
+		case 0x67251051U /* Digit9             */: physicalKey = RGFW_9;                    /* 0x000B */
+		case 0x92E14DD3U /* Minus              */: physicalKey = RGFW_Minus;                /* 0x000C */
+		case 0x92E1FBACU /* Equal              */: physicalKey = RGFW_Equals;                /* 0x000D */
+		case 0x36BF1CB5U /* Backspace          */: physicalKey = RGFW_BackSpace;            /* 0x000E */
+		case 0x7B8E51E2U /* Tab                */: physicalKey = RGFW_Tab;                  /* 0x000F */
+		case 0x2C595B51U /* KeyQ               */: physicalKey = RGFW_q;                    /* 0x0010 */
+		case 0x2C595B57U /* KeyW               */: physicalKey = RGFW_w;                    /* 0x0011 */
+		case 0x2C595B45U /* KeyE               */: physicalKey = RGFW_e;                    /* 0x0012 */
+		case 0x2C595B52U /* KeyR               */: physicalKey = RGFW_r;                    /* 0x0013 */
+		case 0x2C595B54U /* KeyT               */: physicalKey = RGFW_t;                    /* 0x0014 */
+		case 0x2C595B59U /* KeyY               */: physicalKey = RGFW_y;                    /* 0x0015 */
+		case 0x2C595B55U /* KeyU               */: physicalKey = RGFW_u;                    /* 0x0016 */
+		case 0x2C595B4FU /* KeyO               */: physicalKey = RGFW_o;                    /* 0x0018 */
+		case 0x2C595B50U /* KeyP               */: physicalKey = RGFW_p;                    /* 0x0019 */
+		case 0x45D8158CU /* BracketLeft        */: physicalKey = RGFW_CloseBracket;         /* 0x001A */
+		case 0xDEEABF7CU /* BracketRight       */: physicalKey = RGFW_Bracket;        /* 0x001B */
+		case 0x92E1C5D2U /* Enter              */: physicalKey = RGFW_Return;                /* 0x001C */
+		case 0xE058958CU /* ControlLeft        */: physicalKey = RGFW_ControlL;         /* 0x001D */
+		case 0x2C595B41U /* KeyA               */: physicalKey = RGFW_a;                    /* 0x001E */
+		case 0x2C595B53U /* KeyS               */: physicalKey = RGFW_s;                    /* 0x001F */
+		case 0x2C595B44U /* KeyD               */: physicalKey = RGFW_d;                    /* 0x0020 */
+		case 0x2C595B46U /* KeyF               */: physicalKey = RGFW_f;                    /* 0x0021 */
+		case 0x2C595B47U /* KeyG               */: physicalKey = RGFW_g;                    /* 0x0022 */
+		case 0x2C595B48U /* KeyH               */: physicalKey = RGFW_h;                    /* 0x0023 */
+		case 0x2C595B4AU /* KeyJ               */: physicalKey = RGFW_j;                    /* 0x0024 */
+		case 0x2C595B4BU /* KeyK               */: physicalKey = RGFW_k;                    /* 0x0025 */
+		case 0x2C595B4CU /* KeyL               */: physicalKey = RGFW_l;                    /* 0x0026 */
+		case 0x2707219EU /* Semicolon          */: physicalKey = RGFW_Semicolon;            /* 0x0027 */
+		case 0x92E0B58DU /* Quote              */: physicalKey = RGFW_Apostrophe;                /* 0x0028 */
+		case 0x36BF358DU /* Backquote          */: physicalKey = RGFW_Backtick;            /* 0x0029 */
+		case 0x26B1958CU /* ShiftLeft          */: physicalKey = RGFW_ShiftL;           /* 0x002A */
+		case 0x36BF2438U /* Backslash          */: physicalKey = RGFW_BackSlash;            /* 0x002B */
+		case 0x2C595B5AU /* KeyZ               */: physicalKey = RGFW_z;                    /* 0x002C */
+		case 0x2C595B58U /* KeyX               */: physicalKey = RGFW_x;                    /* 0x002D */
+		case 0x2C595B43U /* KeyC               */: physicalKey = RGFW_c;                    /* 0x002E */
+		case 0x2C595B56U /* KeyV               */: physicalKey = RGFW_v;                    /* 0x002F */
+		case 0x2C595B42U /* KeyB               */: physicalKey = RGFW_b;                    /* 0x0030 */
+		case 0x2C595B4EU /* KeyN               */: physicalKey = RGFW_n;                    /* 0x0031 */
+		case 0x2C595B4DU /* KeyM               */: physicalKey = RGFW_m;                    /* 0x0032 */
+		case 0x92E1A1C1U /* Comma              */: physicalKey = RGFW_Comma;                /* 0x0033 */
+		case 0x672FFAD4U /* Period             */: physicalKey = RGFW_Period;               /* 0x0034 */
+		case 0x92E0A438U /* Slash              */: physicalKey = RGFW_Slash;                /* 0x0035 */
+		case 0xC5A6BF7CU /* ShiftRight         */: physicalKey = RGFW_ShiftR;
+		case 0x5D64DA91U /* NumpadMultiply     */: physicalKey = RGFW_Multiply;
+		case 0xC914958CU /* AltLeft            */: physicalKey = RGFW_AltL;             /* 0x0038 */
+		case 0x92E09CB5U /* Space              */: physicalKey = RGFW_Space;                /* 0x0039 */
+		case 0xB8FAE73BU /* CapsLock           */: physicalKey = RGFW_CapsLock;            /* 0x003A */
+		case 0x7174B789U /* F1                 */: physicalKey = RGFW_F1;                   /* 0x003B */
+		case 0x7174B78AU /* F2                 */: physicalKey = RGFW_F2;                   /* 0x003C */
+		case 0x7174B78BU /* F3                 */: physicalKey = RGFW_F3;                   /* 0x003D */
+		case 0x7174B78CU /* F4                 */: physicalKey = RGFW_F4;                   /* 0x003E */
+		case 0x7174B78DU /* F5                 */: physicalKey = RGFW_F5;                   /* 0x003F */
+		case 0x7174B78EU /* F6                 */: physicalKey = RGFW_F6;                   /* 0x0040 */
+		case 0x7174B78FU /* F7                 */: physicalKey = RGFW_F7;                   /* 0x0041 */
+		case 0x7174B780U /* F8                 */: physicalKey = RGFW_F8;                   /* 0x0042 */
+		case 0x7174B781U /* F9                 */: physicalKey = RGFW_F9;                   /* 0x0043 */
+		case 0x7B8E57B0U /* F10                */: physicalKey = RGFW_F10;                  /* 0x0044 */
+		case 0xC925FCDFU /* Numpad7            */: physicalKey = RGFW_Multiply;             /* 0x0047 */
+		case 0xC925FCD0U /* Numpad8            */: physicalKey = RGFW_KP_8;             /* 0x0048 */
+		case 0xC925FCD1U /* Numpad9            */: physicalKey = RGFW_KP_9;             /* 0x0049 */
+		case 0x5EA3E8A4U /* NumpadSubtract     */: physicalKey = RGFW_Minus;      /* 0x004A */
+		case 0xC925FCDCU /* Numpad4            */: physicalKey = RGFW_KP_4;             /* 0x004B */
+		case 0xC925FCDDU /* Numpad5            */: physicalKey = RGFW_KP_5;             /* 0x004C */
+		case 0xC925FCDEU /* Numpad6            */: physicalKey = RGFW_KP_6;             /* 0x004D */
+		case 0xC925FCD9U /* Numpad1            */: physicalKey = RGFW_KP_1;             /* 0x004F */
+		case 0xC925FCDAU /* Numpad2            */: physicalKey = RGFW_KP_2;             /* 0x0050 */
+		case 0xC925FCDBU /* Numpad3            */: physicalKey = RGFW_KP_3;             /* 0x0051 */
+		case 0xC925FCD8U /* Numpad0            */: physicalKey = RGFW_KP_0;             /* 0x0052 */
+		case 0x95852DACU /* NumpadDecimal      */: physicalKey = RGFW_KP_Period;       /* 0x0053 */
+		case 0x7B8E57B1U /* F11                */: physicalKey = RGFW_F11;                  /* 0x0057 */
+		case 0x7B8E57B2U /* F12                */: physicalKey = RGFW_F12;                  /* 0x0058 */
+		case 0x7393FBACU /* NumpadEqual        */: physicalKey = RGFW_KP_Return;
+		case 0xB88EBF7CU /* AltRight           */: physicalKey = RGFW_AltR;            /* 0xE038 */
+		case 0xC925873BU /* NumLock            */: physicalKey = RGFW_Numlock;             /* 0xE045 */
+		case 0x2C595F45U /* Home               */: physicalKey = RGFW_Home;                 /* 0xE047 */
+		case 0xC91BB690U /* ArrowUp            */: physicalKey = RGFW_Up;             /* 0xE048 */
+		case 0x672F9210U /* PageUp             */: physicalKey = RGFW_PageUp;              /* 0xE049 */
+		case 0x3799258CU /* ArrowLeft          */: physicalKey = RGFW_Left;           /* 0xE04B */
+		case 0x4CE33F7CU /* ArrowRight         */: physicalKey = RGFW_Right;          /* 0xE04D */
+		case 0x7B8E55DCU /* End                */: physicalKey = RGFW_End;                  /* 0xE04F */
+		case 0x3799379EU /* ArrowDown          */: physicalKey = RGFW_Down;           /* 0xE050 */
+		case 0xBA90179EU /* PageDown           */: physicalKey = RGFW_PageDown;            /* 0xE051 */
+		case 0x6723CB2CU /* Insert             */: physicalKey = RGFW_Insert;               /* 0xE052 */
+		case 0x6725C50DU /* Delete             */: physicalKey = RGFW_Delete;               /* 0xE053 */
+		case 0x6723658CU /* OSLeft             */: physicalKey = RGFW_SuperL;              /* 0xE05B */
+		case 0x39643F7CU /* MetaRight          */: physicalKey = RGFW_SuperR;           /* 0xE05C */
+	}
+
+	u8 keyCode = RGFW_apiMappedToRGFW((u8)(*((u32*)key)));
+
+	RGFW_events[RGFW_eventLen].type = press ? RGFW_keyPressed : RGFW_keyReleased;
+	memcpy(RGFW_events[RGFW_eventLen].keyName, key, 16);
+	RGFW_events[RGFW_eventLen].physicalKey = physicalKey;
+	RGFW_events[RGFW_eventLen].mappedKey = keyCode;
+	RGFW_events[RGFW_eventLen].lockState = 0;
+	RGFW_eventLen++;
+
+	RGFW_keyboard[keyCode].prev = RGFW_keyboard[keyCode].current;
+	RGFW_keyboard[keyCode].current = 0;
+	
+	RGFW_keyCallback(RGFW_root, RGFW_events[RGFW_eventLen].physicalKey, RGFW_events[RGFW_eventLen].mappedKey, RGFW_events[RGFW_eventLen].keyName, 0, press);
+
+	free(key); 
+	free(code);
+}
+
 void EMSCRIPTEN_KEEPALIVE Emscripten_onDrop(size_t count) {
 	if (!(RGFW_root->_winArgs & RGFW_ALLOW_DND))
 		return;
@@ -8878,8 +8955,6 @@ RGFW_window* RGFW_createWindow(const char* name, RGFW_rect rect, u16 args) {
 	emscripten_set_window_title(name);
 
 	/* load callbacks */
-    emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, EM_FALSE, Emscripten_on_keydown);
-    emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, EM_FALSE, Emscripten_on_keyup);
     emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, EM_FALSE, Emscripten_on_resize);
     emscripten_set_fullscreenchange_callback(EMSCRIPTEN_EVENT_TARGET_DOCUMENT, NULL, EM_FALSE, Emscripten_on_fullscreenchange);
     emscripten_set_mousemove_callback("#canvas", NULL, EM_FALSE, Emscripten_on_mousemove);
@@ -8898,6 +8973,22 @@ RGFW_window* RGFW_createWindow(const char* name, RGFW_rect rect, u16 args) {
 	if (args & RGFW_ALLOW_DND)  {
 		win->_winArgs |= RGFW_ALLOW_DND;
 	}
+
+	EM_ASM({
+		window.addEventListener("keydown",
+			(event) => {
+				Module._RGFW_handleKeyEvent(stringToNewUTF8(event.key), stringToNewUTF8(event.code), 1);
+			}, true,
+		);
+	});
+
+	EM_ASM({
+		window.addEventListener("keyup",
+			(event) => {
+				Module._RGFW_handleKeyEvent(stringToNewUTF8(event.key), stringToNewUTF8(event.code), 0);
+			}, true,
+		);
+	});
 
     EM_ASM({
 		var canvas = document.getElementById('canvas');

--- a/RGFW.h
+++ b/RGFW.h
@@ -4407,13 +4407,14 @@ static void keyboard_key (void *data, struct wl_keyboard *keyboard, uint32_t ser
 	RGFW_Event ev;
 	ev.type = RGFW_keyPressed + state;
 	ev.key = RGFW_key;
+	ev.keyChar = (u8)keysym;
 	strcpy(ev.keyName, name);
 	ev.repeat = RGFW_isHeld(RGFW_key_win, RGFW_key);
 	RGFW_eventPipe_push(RGFW_key_win, ev);
 	
 	RGFW_updateLockState(RGFW_key_win, xkb_keymap_mod_get_index(keymap, "Lock"), xkb_keymap_mod_get_index(keymap, "Mod2"));
 
-	RGFW_keyCallback(RGFW_key_win, RGFW_key, name, RGFW_key_win->event.lockState, state);
+	RGFW_keyCallback(RGFW_key_win, RGFW_key, (u8)keysym, name, RGFW_key_win->event.lockState, state);
 }
 static void keyboard_modifiers (void *data, struct wl_keyboard *keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group) {
 	RGFW_UNUSED(data); RGFW_UNUSED(keyboard); RGFW_UNUSED(serial); RGFW_UNUSED(time); 

--- a/examples/callbacks/callbacks.c
+++ b/examples/callbacks/callbacks.c
@@ -59,12 +59,12 @@ void windowrefreshfunc(RGFW_window* win) {
     printf("refresh\n");
 }
 
-void keyfunc(RGFW_window* win, u32 keycode, char keyName[16], u8 lockState, u8 pressed) {
+void keyfunc(RGFW_window* win, u32 keycode, u32 scancode, char keyName[16], u8 lockState, u8 pressed) {
     if (window != win) return;
     if (pressed)
-        printf("key pressed : %i : %s with lockState : %i\n", keycode, keyName, lockState);
+        printf("key pressed : %i (%c) scan : %i (%c): %s with lockState : %i\n", keycode, keycode, scancode, scancode, keyName, lockState);
     else
-        printf("key released : %i : %s with lockState : %i\n", keycode, keyName, lockState);
+        printf("key released : %i (%c) scan: %i (%c): %s with lockState : %i\n", keycode, keycode, scancode, scancode, keyName, lockState);
 }
 
 void mousebuttonfunc(RGFW_window* win, u8 button, double scroll, u8 pressed) {

--- a/examples/callbacks/callbacks.c
+++ b/examples/callbacks/callbacks.c
@@ -59,12 +59,12 @@ void windowrefreshfunc(RGFW_window* win) {
     printf("refresh\n");
 }
 
-void keyfunc(RGFW_window* win, u32 keycode, u32 scancode, char keyName[16], u8 lockState, u8 pressed) {
+void keyfunc(RGFW_window* win, u32 physicalKey, u32 mappedKey, char keyName[16], u8 lockState, u8 pressed) {
     if (window != win) return;
     if (pressed)
-        printf("key pressed : %i (%c) scan : %i (%c): %s with lockState : %i\n", keycode, keycode, scancode, scancode, keyName, lockState);
+        printf("key pressed : %i (%c) mapped : %i (%c): %s with lockState : %i\n", physicalKey, physicalKey, mappedKey, mappedKey, keyName, lockState);
     else
-        printf("key released : %i (%c) scan: %i (%c): %s with lockState : %i\n", keycode, keycode, scancode, scancode, keyName, lockState);
+        printf("key released : %i (%c) mapped: %i (%c): %s with lockState : %i\n", physicalKey, physicalKey, mappedKey, mappedKey, keyName, lockState);
 }
 
 void mousebuttonfunc(RGFW_window* win, u8 button, double scroll, u8 pressed) {

--- a/examples/first-person-camera/camera.c
+++ b/examples/first-person-camera/camera.c
@@ -57,7 +57,7 @@ int main(void) {
                     break;
                 }
                 case RGFW_keyPressed:
-                    switch (win->event.keyCode) {
+                    switch (win->event.physicalKey) {
                         case RGFW_Return:
                             RGFW_window_showMouse(win, 0);
                             RGFW_window_mouseHold(win, RGFW_AREA(win->r.w / 2, win->r.h / 2));    

--- a/examples/first-person-camera/camera.c
+++ b/examples/first-person-camera/camera.c
@@ -57,7 +57,7 @@ int main(void) {
                     break;
                 }
                 case RGFW_keyPressed:
-                    switch (win->event.physicalKey) {
+                    switch (win->event.key) {
                         case RGFW_Return:
                             RGFW_window_showMouse(win, 0);
                             RGFW_window_mouseHold(win, RGFW_AREA(win->r.w / 2, win->r.h / 2));    

--- a/examples/microui_demo/microui_demo.c
+++ b/examples/microui_demo/microui_demo.c
@@ -267,12 +267,11 @@ int main(int argc, char **argv) {
         }
 		
         case RGFW_keyPressed: {
-		  char str[2] = {'\0', '\0'};
-		  str[0] = RGFW_keyCodeToCharAuto(window->event.keyCode, window->event.lockState);
+		  char str[2] = {window->event.keyChar, '\0'};
 		  mu_input_text(ctx, str);
 	    }
 		case RGFW_keyReleased: {
-          int c = key_map[window->event.keyCode & 0xff];
+          int c = key_map[window->event.key & 0xff];
           if (c && window->event.type == RGFW_keyPressed) { mu_input_keydown(ctx, c); }
           if (c && window->event.type == RGFW_keyReleased) { mu_input_keyup(ctx, c);   }
           break;


### PR DESCRIPTION
This PR exists in order organize my thoughts for the rewrite, allow for public comments and transparency, and to allow me to work on this change synchronously with other updates.  

Brief explanation:

Scancodes are codes from key input which refer to the actual physical key that is pressed. 
For example, Q may be referred to as `21` being the 1st key on the 2nd row. (Note: this number is not based on how scancodes work in real life, but only for an example) That key can then be mapped by software such as SDL or RGFW to a standard key format such as QWERTY. Allowing you to use `KEY_Q` to refer to the 1st key on the 2nd row no matter which keyboard you use. On a French Keyboard, that key would be `KEY_A`,  however the scancode would still be `KEY_Q`

Keycodes are mapped codes from key input. They are mapped by the OS based on the keyboard's set format. For example, with the French keyboard, when the A key is pressed, the keycode would be `KEY_A` . 

Scancodes are based on key placement, making them good for controls;
keycodes are based on key mapping, making them good for text input. 

Currently, RGFW does not have any special sort of API for keycodes and scancodes. It was not designed with this difference in mind, which results in a few API flaws:

- RGFW keymap code mixes keycodes and scancodes:

linux: 
event.keycode -> scancode, 
event.keyname -> keycode

windows:
event.keycode -> keycode,
event.keyname -> keycode

macOS:
event.keycode -> scancode
event.keyname -> keycode

web: 
event.keycode -> keycode
event.keyname -> keycode


Features to implement: 

- Allow for the user to receive both they keycode and scancode in some way. 
-  Standardize key conversion (use scancodes or keycodes for both)
- Create a separate LUT for key and scancodes OR find a different way to convert the scancode to the keycode OR use only scancodes then send a char for the keycode (This is what GLFW does).