### PR TITLE
Gamepad update 2

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -7464,7 +7464,7 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 			RGFW_gamepads[i] = i;
 			RGFW_gamepadCount++;
 			
-			Event ev;
+			RGFW_Event ev;
 			ev.type = RGFW_gpConnected;
 			ev.gamepad = i;
 			RGFW_gpEventQueue[RGFW_gpEventQueueCount] = ev;
@@ -7489,12 +7489,12 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 		if (index != -1)
 			RGFW_osxControllers[index] = NULL;
 
-		Event ev;
+		RGFW_Event ev;
 		ev.type = RGFW_gpDisconnected;
-		ev.gamepad = i;
+		ev.gamepad = index;
 		RGFW_gpEventQueue[RGFW_gpEventQueueCount] = ev;
 		RGFW_gpEventQueueCount++;
-		RGFW_gamepadCallback(RGFW_root, i, 0);
+		RGFW_gamepadCallback(RGFW_root, index, 0);
 
 		RGFW_gamepadCount--;
 	}
@@ -8896,7 +8896,7 @@ EM_BOOL Emscripten_on_gamepad(int eventType, const EmscriptenGamepadEvent *gamep
 	if (gamepadEvent->connected) {
 		memcpy(RGFW_gamepads_name[gamepadEvent->index], gamepadEvent->id, sizeof(RGFW_gamepads_name[gamepadEvent->index]));
 		RGFW_gamepadCount++;
-		RGFW_events[RGFW_eventLen].type = RGFW_gpisconnected;
+		RGFW_events[RGFW_eventLen].type = RGFW_gpConnected;
 	} else {
 		RGFW_gamepadCount--;
 		RGFW_events[RGFW_eventLen].type = RGFW_gpDisconnected;

--- a/RGFW.h
+++ b/RGFW.h
@@ -5769,7 +5769,7 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 
 				if (keystroke.VirtualKey > VK_PAD_RTHUMB_PRESS)
 					continue;
-
+				printf("h\n");
 				//gp + 1 = RGFW_gpButtonReleased
 				e->type = RGFW_gpButtonPressed + !(keystroke.Flags & XINPUT_KEYSTROKE_KEYDOWN);
 				e->button = RGFW_xinput2RGFW[keystroke.VirtualKey - 0x5800];
@@ -5783,6 +5783,9 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 			if (XInputGetState == NULL ||
 				XInputGetState((DWORD) i, &state) == ERROR_DEVICE_NOT_CONNECTED
 			) {
+				if (RGFW_gamepads[i] == 0)
+					continue;
+				
 				RGFW_gamepads[i] = 0;
 				RGFW_gamepadCount--;
 				

--- a/RGFW.h
+++ b/RGFW.h
@@ -2326,7 +2326,7 @@ This is where OS specific stuff starts
 				ssize_t bytes;
 				while ((bytes = read(RGFW_gamepads[i], &e, sizeof(e))) > 0) {
 					switch (e.type) {
-						case JS_EVENT_BUTTON:
+						case JS_EVENT_BUTTON: {
 							size_t typeIndex = 0;
 							if (RGFW_gamepads_type[i] == RGFW_MICROSOFT)
 								typeIndex = 1;
@@ -2348,6 +2348,7 @@ This is where OS specific stuff starts
 							RGFW_gpButtonCallback(win, i, win->event.button, e.value);
 							
 							return 1;
+						}
 						case JS_EVENT_AXIS: {
 							size_t axis = e.number / 2;
 							if (axis == 2) axis = 1;
@@ -8928,6 +8929,7 @@ EM_BOOL Emscripten_on_gamepad(int eventType, const EmscriptenGamepadEvent *gamep
 	if (gamepadEvent->index >= 4)
 		return 0;
 
+	size_t i = gamepadEvent->index;
 	if (gamepadEvent->connected) {
 		memcpy(RGFW_gamepads_name[gamepadEvent->index], gamepadEvent->id, sizeof(RGFW_gamepads_name[gamepadEvent->index]));
 		RGFW_gamepads_type[i] = RGFW_UNKNOWN;

--- a/RGFW.h
+++ b/RGFW.h
@@ -5759,17 +5759,26 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 			) {
 				RGFW_gamepads[i] = 0;
 				RGFW_gamepadCount--;
-				return 0;
+				
+				win->event.type = RGFW_gpDisconnected;
+				win->event.gamepad = i;
+				RGFW_gamepadCallback(win, i, 0);
+				return 1;
 			}
 			
 			if (RGFW_gamepads[i] == 0) {
 				RGFW_gamepads[i] = 1;
 				RGFW_gamepadCount++;
 
-				
+				char str[] = "Microsoft X-Box (XInput device)";
+				memcpy(RGFW_gamepads_name[i], str, sizeof(str));
 				RGFW_gamepads_name[i][sizeof(RGFW_gamepads_name[i]) - 1] = '\0';
+				win->event.type = RGFW_gpConnected;
+				win->event.gamepad = i;
+				RGFW_gamepadCallback(win, i, 1);
+				return 1;
 			}
-
+ 
 #define INPUT_DEADZONE  ( 0.24f * (float)(0x7FFF) )  // Default to 24% of the +/- 32767 range.   This is a reasonable default value but can be altered if needed.
 
 			if ((state.Gamepad.sThumbLX < INPUT_DEADZONE &&
@@ -7454,6 +7463,13 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 			
 			RGFW_gamepads[i] = i;
 			RGFW_gamepadCount++;
+			
+			Event ev;
+			ev.type = RGFW_gpConnected;
+			ev.gamepad = i;
+			RGFW_gpEventQueue[RGFW_gpEventQueueCount] = ev;
+			RGFW_gpEventQueueCount++;
+			RGFW_gamepadCallback(RGFW_root, i, 1);
 			break;
 		}
 	}
@@ -7472,6 +7488,13 @@ RGFW_UNUSED(win); /*!< if buffer rendering is not being used */
 		i32 index = findControllerIndex(device);
 		if (index != -1)
 			RGFW_osxControllers[index] = NULL;
+
+		Event ev;
+		ev.type = RGFW_gpDisconnected;
+		ev.gamepad = i;
+		RGFW_gpEventQueue[RGFW_gpEventQueueCount] = ev;
+		RGFW_gpEventQueueCount++;
+		RGFW_gamepadCallback(RGFW_root, i, 0);
 
 		RGFW_gamepadCount--;
 	}
@@ -8873,7 +8896,16 @@ EM_BOOL Emscripten_on_gamepad(int eventType, const EmscriptenGamepadEvent *gamep
 	if (gamepadEvent->connected) {
 		memcpy(RGFW_gamepads_name[gamepadEvent->index], gamepadEvent->id, sizeof(RGFW_gamepads_name[gamepadEvent->index]));
 		RGFW_gamepadCount++;
-	} else RGFW_gamepadCount--;
+		RGFW_events[RGFW_eventLen].type = RGFW_gpisconnected;
+	} else {
+		RGFW_gamepadCount--;
+		RGFW_events[RGFW_eventLen].type = RGFW_gpDisconnected;
+	}
+
+	RGFW_events[RGFW_eventLen].gamepad = gamepadEvent->index;
+	RGFW_eventLen++;
+
+	RGFW_gamepadCallback(RGFW_root, gamepadEvent->index, gamepadEvent->connected);
 
 	RGFW_gamepads[gamepadEvent->index] = gamepadEvent->connected;
 

--- a/examples/gamepad/gamepad.c
+++ b/examples/gamepad/gamepad.c
@@ -104,6 +104,9 @@ void drawLine(int cx, int cy, int x2, int y2, RGFW_window* w) {
 
 void colorIfPressed(RGFW_window* win, size_t gamepad, u32 button) {
     if (RGFW_isPressedGP(win, gamepad, button))
+        printf("%i %i\n",  gamepad, button);
+    
+    if (RGFW_isPressedGP(win, gamepad, button))
         glColor3f(0.8, 0, 0);
     else 
         glColor3f(0.3, 0.3, 0.3);
@@ -148,7 +151,7 @@ void drawGamepad(RGFW_window* w, size_t gamepad) {
     drawCircle(436, 150, 9, w);
     colorIfPressed(w, gamepad, RGFW_GP_SELECT);
     drawCircle(352, 150, 9, w);
-    colorIfPressed(w, gamepad, RGFW_GP_START);
+    colorIfPressed(w, gamepad, RGFW_GP_HOME);
     drawCircle(394, 110, 20, w);
 
     colorIfPressed(w, gamepad, RGFW_GP_X);

--- a/examples/gamepad/gamepad.c
+++ b/examples/gamepad/gamepad.c
@@ -10,6 +10,8 @@ void drawGamepad(RGFW_window* w, size_t gamepad);
 int main(void) {
 	RGFW_window* win = RGFW_createWindow("RGFW Example Window", RGFW_RECT(0, 0, 800, 450), RGFW_CENTER);
     RGFW_window_makeCurrent(win);
+
+    size_t gamepad = 0;
     
     while (RGFW_window_shouldClose(win) == RGFW_FALSE) {
         while (RGFW_window_checkEvent(win) != NULL) {
@@ -24,17 +26,20 @@ int main(void) {
                     printf("Gamepad (%i) axis (%i) {%i, %i}\n", win->event.gamepad, win->event.whichAxis, win->event.axis[win->event.whichAxis].x, win->event.axis[win->event.whichAxis].y);
                     break;
                 case RGFW_gpConnected:
-                    printf("Gamepad (%i) connected\n", win->event.gamepad, RGFW_getGamepadName(win, win->event.gamepad));
+                    printf("Gamepad (%i) connected %s\n", win->event.gamepad, RGFW_getGamepadName(win, win->event.gamepad));
                     break;
                 case RGFW_gpDisconnected:
-                    printf("Gamepad (%i) disconnected\n", win->event.gamepad, RGFW_getGamepadName(win, win->event.gamepad));
+                    printf("Gamepad (%i) disconnected %s\n", win->event.gamepad, RGFW_getGamepadName(win, win->event.gamepad));
                 break;
                 
                 default: break;
             }
+        
+            if (RGFW_isPressed(win, RGFW_Left) && gamepad > 0) gamepad--;
+            if (RGFW_isPressed(win, RGFW_Right) && (gamepad + 1) < RGFW_getGamepadCount(win)) gamepad++;
         }
 
-        drawGamepad(win, 0);
+        drawGamepad(win, gamepad);
     }
 
     RGFW_window_close(win);

--- a/examples/gamepad/gamepad.c
+++ b/examples/gamepad/gamepad.c
@@ -79,6 +79,29 @@ void drawRect(int cx, int cy, int width, int height, RGFW_window* w) {
     glColor3f(0.3, 0.3, 0.3);
 }
 
+
+void drawLine(int cx, int cy, int x2, int y2, RGFW_window* w) {
+    float thickness = 2;
+    float dx = x2 - cx;
+    float dy = y2 - cy;
+    float length = sqrt(dx * dx + dy * dy);
+    float ux = dx / length;
+    float uy = dy / length;
+
+    float offsetX = -uy * thickness / 2;
+    float offsetY = ux * thickness / 2;
+
+    glBegin(GL_TRIANGLES);
+        glVertex2f(RFONT_GET_WORLD(cx + offsetX, cy + offsetY));
+        glVertex2f(RFONT_GET_WORLD(cx - offsetX, cy - offsetY));
+        glVertex2f(RFONT_GET_WORLD(x2 + offsetX, y2 + offsetY));
+
+        glVertex2f(RFONT_GET_WORLD(cx - offsetX, cy - offsetY));
+        glVertex2f(RFONT_GET_WORLD(x2 + offsetX, y2 + offsetY));
+        glVertex2f(RFONT_GET_WORLD(x2 - offsetX, y2 - offsetY));
+    glEnd();
+}
+
 void colorIfPressed(RGFW_window* win, size_t gamepad, u32 button) {
     if (RGFW_isPressedGP(win, gamepad, button))
         glColor3f(0.8, 0, 0);
@@ -87,13 +110,23 @@ void colorIfPressed(RGFW_window* win, size_t gamepad, u32 button) {
 }
 
 void drawGamepad(RGFW_window* w, size_t gamepad) {
-
     glClear(GL_COLOR_BUFFER_BIT);
     glClearColor(0.8, 0.8, 0.8, 1.0);  
 
-    glColor3f(0.05, 0.05, 0.05); // Frame color: Black
-    
-    
+    glColor3f(0.00, 0.00, 0.00);
+    if (gamepad == 3) {
+        RGFW_rect r = {w->r.w - 100 + 20, w->r.h - 100, 50, 80};
+        drawRect(r.x - 20, r.y, 2, r.h, w);
+        drawLine(r.x, r.y, r.x + r.w / 2, r.y + r.h, w);
+        drawLine(r.x + r.w / 2, r.y + r.h, r.x + r.w, r.y, w);
+    }
+    else {
+        for (size_t i = 0; i <= gamepad; i++)
+            drawRect(w->r.w - 100 + (i * 20), w->r.h - 100, 2, 80, w);
+    }
+
+    glColor3f(0.05, 0.05, 0.05);
+
     #ifndef __EMSCRIPTEN__
     glBegin(GL_POLYGON);
         glVertex2f(RFONT_GET_WORLD(250, 45));   // Top-left corner
@@ -115,6 +148,9 @@ void drawGamepad(RGFW_window* w, size_t gamepad) {
     drawCircle(436, 150, 9, w);
     colorIfPressed(w, gamepad, RGFW_GP_SELECT);
     drawCircle(352, 150, 9, w);
+    colorIfPressed(w, gamepad, RGFW_GP_START);
+    drawCircle(394, 110, 20, w);
+
     colorIfPressed(w, gamepad, RGFW_GP_X);
     drawCircle(501, 151, 15, w);
     colorIfPressed(w, gamepad, RGFW_GP_A);

--- a/examples/gamepad/gamepad.c
+++ b/examples/gamepad/gamepad.c
@@ -23,6 +23,12 @@ int main(void) {
                 case RGFW_gpAxisMove:
                     printf("Gamepad (%i) axis (%i) {%i, %i}\n", win->event.gamepad, win->event.whichAxis, win->event.axis[win->event.whichAxis].x, win->event.axis[win->event.whichAxis].y);
                     break;
+                case RGFW_gpConnected:
+                    printf("Gamepad (%i) connected\n", win->event.gamepad, RGFW_getGamepadName(win, win->event.gamepad));
+                    break;
+                case RGFW_gpDisconnected:
+                    printf("Gamepad (%i) disconnected\n", win->event.gamepad, RGFW_getGamepadName(win, win->event.gamepad));
+                break;
                 
                 default: break;
             }

--- a/examples/gamepad/gamepad.c
+++ b/examples/gamepad/gamepad.c
@@ -104,9 +104,6 @@ void drawLine(int cx, int cy, int x2, int y2, RGFW_window* w) {
 
 void colorIfPressed(RGFW_window* win, size_t gamepad, u32 button) {
     if (RGFW_isPressedGP(win, gamepad, button))
-        printf("%i %i\n",  gamepad, button);
-    
-    if (RGFW_isPressedGP(win, gamepad, button))
         glColor3f(0.8, 0, 0);
     else 
         glColor3f(0.3, 0.3, 0.3);


### PR DESCRIPTION
This is the second major update for gamepad support. This is because there are still some very important missing features. 

* gamepad connection event
* gamepad connection event callback
* gamepad disconnection event
* gamepad disconnection event callback
* way to get the number of gamepads connected (RGFW_getGamepadCount)
* way to get the name of the gamepad (RGFW_getGamepadName) 

and a major issue:

Switch mappings depending on which controller is connected. My current idea is to do Microsoft versus non-Microsoft controllers. All this would require for most backends is to check if the gamepad name includes the substring "Microsoft" using `strstr`. The result can be cached to avoid running `strstr` each time the controller sends input. 