### PR TITLE
fixing a bug where win->_flags got cleared after calling RGFW_window_setFlags

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -1819,7 +1819,8 @@ void RGFW_window_setFlags(RGFW_window* win, RGFW_windowFlags flags) {
 	if (flags & RGFW_windowFloating)				RGFW_window_setFloating(win, 1);
 	else if (cmpFlags & RGFW_windowFloating)		RGFW_window_setFloating(win, 0);
 
-	if (!(win->_flags & RGFW_WINDOW_INIT)) win->_flags |= RGFW_WINDOW_INIT;
+        if (win->_flags & RGFW_WINDOW_INIT) cmpFlags = 0;
+	if ((win->_flags & RGFW_WINDOW_ALLOC)) flags |= RGFW_WINDOW_ALLOC;
 	win->_flags = flags;
 }
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -1820,7 +1820,6 @@ void RGFW_window_setFlags(RGFW_window* win, RGFW_windowFlags flags) {
 	if (flags & RGFW_windowFloating)				RGFW_window_setFloating(win, 1);
 	else if (cmpFlags & RGFW_windowFloating)		RGFW_window_setFloating(win, 0);
 
-        if (win->_flags & RGFW_WINDOW_INIT) cmpFlags = 0;
         win->_flags = flags | (win->_flags & RGFW_INTERNAL_FLAGS);
 }
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -1799,7 +1799,7 @@ void RGFW_window_basic_init(RGFW_window* win, RGFW_rect rect, RGFW_windowFlags f
 
 void RGFW_window_setFlags(RGFW_window* win, RGFW_windowFlags flags) {
 	RGFW_windowFlags cmpFlags = win->_flags; 
-	if (win->_flags & RGFW_WINDOW_INIT) cmpFlags = win->_flags;
+	if (win->_flags & RGFW_WINDOW_INIT) cmpFlags = 0;
 
 	#ifndef RGFW_NO_MONITOR
 	if (flags & RGFW_windowScaleToMonitor)			RGFW_window_scaleToMonitor(win);


### PR DESCRIPTION
fixed the issue where `RGFW_createWindow` calls `RGFW_createWindowPtr` which calls `RGFW_window_setFlags` which reassigns win->_flags causing RGFW_WINDOW_ALLOC to get unset which causes the window to not get freed later.