### PR TITLE
Fix restoring incorrect window rect when exiting fullscreen

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -6346,13 +6346,13 @@ void RGFW_window_setFullscreen(RGFW_window* win, RGFW_bool fullscreen) {
 		return;
 	}
 
+	win->_oldRect = win->r;
 	win->_flags |= RGFW_windowFullscreen;
 
 	RGFW_monitor mon  = RGFW_window_getMonitor(win);
 	RGFW_window_setBorder(win, 0);
 	SetWindowPos(win->src.window, HWND_TOPMOST, 0, 0, mon.mode.area.w, mon.mode.area.h, SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
 
-	win->_oldRect = win->r;
 	win->r = RGFW_RECT(0, 0, mon.mode.area.w, mon.mode.area.h);
 }
 


### PR DESCRIPTION
### Issue
When setting fullscreen to `false`, the window does not properly restore its previous size and position due to `_oldRect` being set after modification. This causes incorrect restoration behavior.

### Fix
Move `win->_oldRect = win->r;` above the fullscreen mode change to correctly save the previous window size before modification.
```c
void RGFW_window_setFullscreen(RGFW_window* win, RGFW_bool fullscreen) {
    ...

    win->_oldRect = win->r; // <<< here
    win->_flags |= RGFW_windowFullscreen;

    RGFW_monitor mon = RGFW_window_getMonitor(win);
    RGFW_window_setBorder(win, 0);
    SetWindowPos(win->src.window, HWND_TOPMOST,
                 0, 0, mon.mode.area.w, mon.mode.area.h,
                 SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
    
    // win->_oldRect = win->r; // <<< moved 
    win->r = RGFW_RECT(0, 0, mon.mode.area.w, mon.mode.area.h);
}
```

### Test
Before fix:

https://github.com/user-attachments/assets/3eab6525-a679-42b9-95fb-8c02405210b4

After fix:

https://github.com/user-attachments/assets/5a0c8b0a-37d7-4847-aeef-cb1af52b54dc


