### PR TITLE
Transparency bug in cursor & window icon on Windows

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -6995,9 +6995,9 @@ HICON RGFW_loadHandleImage(u8* src, RGFW_area a, BOOL icon) {
 	HDC maskDC = CreateCompatibleDC(dc);
 	SelectObject(maskDC, mask);
 
-	for (i32 y = 0; y < a.h; y++) {
-		for (i32 x = 0; x < a.w; x++) {
-			i32 index = (y * a.w + x) * 4;
+	for (u32 y = 0; y < a.h; y++) {
+		for (u32 x = 0; x < a.w; x++) {
+			u32 index = (y * a.w + x) * 4;
 			u8 alpha = src[index + 3];
 			if (alpha < 128) {
 				SetPixel(maskDC, x, y, RGB(255, 255, 255));

--- a/RGFW.h
+++ b/RGFW.h
@@ -6997,7 +6997,7 @@ HICON RGFW_loadHandleImage(u8* src, RGFW_area a, BOOL icon) {
 
 	for (i32 y = 0; (u32)y < a.h; y++) {
 		for (i32 x = 0; (u32)x < a.w; x++) {
-			i32 index = (y * a.w + x) * 4;
+			u32 index = ((u32)y * a.w + (u32)x) * 4;
 			u8 alpha = src[index + 3];
 			if (alpha < 128) {
 				SetPixel(maskDC, x, y, RGB(255, 255, 255));

--- a/RGFW.h
+++ b/RGFW.h
@@ -6990,9 +6990,25 @@ HICON RGFW_loadHandleImage(u8* src, RGFW_area a, BOOL icon) {
 		NULL, (DWORD) 0);
 	
 	memcpy(target, src, a.w * a.h * 4);
-	ReleaseDC(NULL, dc);
-
+	
 	HBITMAP mask = CreateBitmap((i32)a.w, (i32)a.h, 1, 1, NULL);
+	HDC maskDC = CreateCompatibleDC(dc);
+	SelectObject(maskDC, mask);
+
+	for (i32 y = 0; y < a.h; y++) {
+		for (i32 x = 0; x < a.w; x++) {
+			i32 index = (y * a.w + x) * 4;
+			u8 alpha = src[index + 3];
+			if (alpha < 128) {
+				SetPixel(maskDC, x, y, RGB(255, 255, 255));
+			} else {
+				SetPixel(maskDC, x, y, RGB(0, 0, 0));
+			}
+		}
+	}
+	
+	DeleteDC(maskDC);
+	ReleaseDC(NULL, dc);
 
 	ICONINFO ii;
 	ZeroMemory(&ii, sizeof(ii));

--- a/RGFW.h
+++ b/RGFW.h
@@ -6995,9 +6995,9 @@ HICON RGFW_loadHandleImage(u8* src, RGFW_area a, BOOL icon) {
 	HDC maskDC = CreateCompatibleDC(dc);
 	SelectObject(maskDC, mask);
 
-	for (u32 y = 0; y < a.h; y++) {
-		for (u32 x = 0; x < a.w; x++) {
-			u32 index = (y * a.w + x) * 4;
+	for (i32 y = 0; (u32)y < a.h; y++) {
+		for (i32 x = 0; (u32)x < a.w; x++) {
+			i32 index = (y * a.w + x) * 4;
 			u8 alpha = src[index + 3];
 			if (alpha < 128) {
 				SetPixel(maskDC, x, y, RGB(255, 255, 255));


### PR DESCRIPTION
## Issue
Hi, I noticed that `RGFW_loadHandleImage` isn't handling transparency correctly. Pixels with `alpha = 0` are supposed to be transparent, but instead, they display as black. Looks kinda weird.
I think the issue come from how Windows handles mask bitmaps in `ICONINFO`. The mask uses black (0) for opaque pixels and white (255) for transparent pixels

## Fix
### 1. I made a fix for this. Not sure if it aligns with RGFW’s goals, but here it is:
```c
HICON RGFW_loadHandleImage(u8* src, RGFW_area a, BOOL icon) {
	...
	...

	HBITMAP mask = CreateBitmap((i32)a.w, (i32)a.h, 1, 1, NULL);
	HDC maskDC = CreateCompatibleDC(dc);
	SelectObject(maskDC, mask);

	for (i32 y = 0; (u32)y < a.h; y++) {
		for (i32 x = 0; (u32)x < a.w; x++) {
			u32 index = ((u32)y * a.w + (u32)x) * 4;
			u8 alpha = src[index + 3];
			if (alpha < 128) {
				SetPixel(maskDC, x, y, RGB(255, 255, 255));
			} else {
				SetPixel(maskDC, x, y, RGB(0, 0, 0));
			}
		}
	}
	
	DeleteDC(maskDC);
	ReleaseDC(NULL, dc);

	ICONINFO ii;
	ZeroMemory(&ii, sizeof(ii));
	ii.fIcon = icon;
	ii.xHotspot = a.w / 2;
	ii.yHotspot = a.h / 2;
	ii.hbmMask = mask;
	ii.hbmColor = color;

	HICON handle = CreateIconIndirect(&ii);

	DeleteObject(color);
	DeleteObject(mask);

	return handle;
}
```
### 2. I also tried another way that worked but didn’t commit it:
```c
HICON RGFW_loadHandleImage(u8* src, RGFW_area a, BOOL icon) {
	BITMAPV5HEADER bi;
	ZeroMemory(&bi, sizeof(bi));
	bi.bV5Size = sizeof(bi);
	bi.bV5Width = (i32)a.w;
	bi.bV5Height = -((LONG) a.h);
	bi.bV5Planes = 1;
	bi.bV5BitCount = 32;
	bi.bV5Compression = BI_RGB; // replaced BI_BITFIELDS
	bi.bV5RedMask = 0x000000ff;
	bi.bV5GreenMask = 0x0000ff00;
	bi.bV5BlueMask = 0x00ff0000; 
	bi.bV5AlphaMask = 0xff000000;

	HDC dc = GetDC(NULL);

	...
}
```

### Test
Image that I use:
![RPG_Portraits_21](https://github.com/user-attachments/assets/c9f5f9ba-648d-4908-a8c5-25e17c127401)

```c
u8 icon[] = {...};
RGFW_window_setIcon(win, &icon, RGFW_AREA(128, 128), 4);
RGFW_mouse* mouse = RGFW_loadMouse(&icon, RGFW_AREA(128, 128), 4);
RGFW_window_setMouse(win, mouse);
```
| Before fix | After fix |
| ---------- | --------- |
| ![Screenshot 2025-03-17 022536](https://github.com/user-attachments/assets/c6729230-0bfb-4df9-a5f7-7448f3ec0aab) | ![Screenshot 2025-03-17 022524](https://github.com/user-attachments/assets/ad0be81b-613d-4cfc-bce5-8aef8c0bb1de) |

*Let me know what you think! 🙂*

