### PR TITLE
gamepad review

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -3089,7 +3089,7 @@ RGFW_event* RGFW_updateGamepad(void) {
 
             event.type = RGFW_gamepadDisconnected;
             event.gamepad = i;
-            RGFW_gamepadCallback(win, i, 0);
+            RGFW_gamepadCallback(RGFW_root, i, 0);
             return &event;
         }
     }

--- a/RGFW.h
+++ b/RGFW.h
@@ -3076,7 +3076,7 @@ RGFW_event* RGFW_updateGamepad(void) {
                     event.type = RGFW_gamepadAxisMove;
                     event.gamepad = i;
                     event.whichAxis = (u8)axis;
-                    RGFW_gamepadAxisCallback(_RGFW.root, i, win->event.axis, win->event.axisesCount, win->event.whichAxis);
+                    RGFW_gamepadAxisCallback(_RGFW.root, i, event.axis, event.axisesCount, event.whichAxis);
                     return &event;
                 }
                 default: break;
@@ -3087,10 +3087,10 @@ RGFW_event* RGFW_updateGamepad(void) {
             close(RGFW_gamepads[i]);
             RGFW_gamepads[i] = 0;
 
-            win->event.type = RGFW_gamepadDisconnected;
-            win->event.gamepad = i;
+            event.type = RGFW_gamepadDisconnected;
+            event.gamepad = i;
             RGFW_gamepadCallback(win, i, 0);
-            return &win->event;
+            return &event;
         }
     }
 	#endif

--- a/RGFW.h
+++ b/RGFW.h
@@ -2054,7 +2054,7 @@ void RGFW_window_setFlags(RGFW_window* win, RGFW_windowFlags flags) {
 
 RGFW_bool RGFW_window_updateGamepad(RGFW_window* win);
 RGFW_bool RGFW_window_updateGamepad(RGFW_window* win) {
-    if (win->_flags |= RGFW_windowNoGamepad) return RGFW_FALSE;
+    if (win->_flags & RGFW_windowNoGamepad) return RGFW_FALSE;
     
     RGFW_event* ev = RGFW_updateGamepad();
 	if (ev != NULL) {	
@@ -2945,6 +2945,8 @@ This is where OS specific stuff starts
 
 RGFW_event* RGFW_updateGamepad(void) {
 #if defined(__linux__) && !defined(RGFW_NO_LINUX)
+    static RGFW_event event;
+
     /* check for new gamepads */
     static const char* str[] = {"/dev/input/js0", "/dev/input/js1", "/dev/input/js2", "/dev/input/js3", "/dev/input/js4", "/dev/input/js5"};
     static u8 RGFW_rawGamepads[6];
@@ -3054,6 +3056,7 @@ RGFW_event* RGFW_updateGamepad(void) {
 
                     return &event;
                 }
+                    break;
                 case JS_EVENT_AXIS: {
                     size_t axis = e.number / 2;
                     if (axis == 2) axis = 1;

--- a/RGFW.h
+++ b/RGFW.h
@@ -3484,11 +3484,6 @@ Start of Linux / Unix defines
 #include <limits.h> /* for data limits (mainly used in drag and drop functions) */
 #include <poll.h>
 
-
-#if defined(__linux__) && !defined(RGFW_NO_LINUX)
-#include <linux/joystick.h>
-#endif
-
 /* atoms needed for drag and drop */
 Atom XdndAware, XtextPlain, XtextUriList;
 Atom RGFW_XUTF8_STRING = 0;

--- a/RGFW.h
+++ b/RGFW.h
@@ -3089,7 +3089,7 @@ RGFW_event* RGFW_updateGamepad(void) {
 
             event.type = RGFW_gamepadDisconnected;
             event.gamepad = i;
-            RGFW_gamepadCallback(RGFW_root, i, 0);
+            RGFW_gamepadCallback(_RGFW.root, i, 0);
             return &event;
         }
     }

--- a/RGFW.h
+++ b/RGFW.h
@@ -3090,7 +3090,7 @@ RGFW_event* RGFW_updateGamepad(void) {
 
             event.type = RGFW_gamepadDisconnected;
             event.gamepad = i;
-            RGFW_gamepadCallback(_RGFW_root, i, 0);
+            RGFW_gamepadCallback(_RGFW.root, i, 0);
             return &event;
         }
     }

--- a/examples/gl33/gl33.c
+++ b/examples/gl33/gl33.c
@@ -20,6 +20,7 @@
 #define RGFW_IMPLEMENTATION
 #define RGFW_PRINT_ERRORS
 #define RGFW_DEBUG
+#define RGFW_NO_GAMEPAD
 #include <RGFW.h>
 
 #define MULTILINE_STR(...) #__VA_ARGS__


### PR DESCRIPTION
# goals

linux, windows, macos, wasm:

- Get the gamepad's GUID
- Add custom mapping support
- Add support for custom mapping using the SDL controller database.

linux:
- Add evdev support (either replacing or working along with joydev) 
- disable joydev or evdev with a macro
- have some runtime way to disable joydev or evdev

windows:
- Add directInput support (to work along with XInput)
- disable xinput or directinput with a macro
- have some runtime way to disable xinput or directinput

# goals accomplished
- allow gamepad events to be checked outside of `RGFW_window_checkEvent` with `RGFW_updateGamepad` and the `RGFW_windowNoGamepad` flag
(should be tested before pull)
- Disable gamepad features with macro
