### PR TITLE
Fix RGFW_window_setShouldClose usage in example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This library does not
 
 void keyfunc(RGFW_window* win, RGFW_key key, char keyChar, RGFW_keymod keyMod, RGFW_bool pressed) {
     if (key == RGFW_escape && pressed) {
-        RGFW_window_setShouldClose(win);
+        RGFW_window_setShouldClose(win, 1);
     }
 }
 

--- a/examples/custom-backend/custom-backend.c
+++ b/examples/custom-backend/custom-backend.c
@@ -5,7 +5,7 @@
 
 void keyfunc(RGFW_window* win, RGFW_key key, char keyChar, RGFW_keymod keyMod, b8 pressed) {
     if (key == RGFW_escape && pressed) {
-        RGFW_window_setShouldClose(win);
+        RGFW_window_setShouldClose(win, 1);
     }
 }
 


### PR DESCRIPTION
In RGFW v1.7.0, the signature of `RGFW_window_setShouldClose` changed to:

    void RGFW_window_setShouldClose(RGFW_window* win, RGFW_bool shouldClose);

This PR updates every example that previously called `RGFW_window_setShouldClose(win)` to:

    RGFW_window_setShouldClose(win, 1);

(where `1` == `RGFW_TRUE`). All affected examples now compile without missing‐parameter errors.
