### PR TITLE
Fix type mismatch in key callback and normalize float literal usage in OpenGL calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This library does not
 
 #include <stdio.h>
 
-void keyfunc(RGFW_window* win, RGFW_key key, char keyChar, RGFW_keymod keyMod, RGFW_bool pressed) {
+void keyfunc(RGFW_window* win, RGFW_key key, u8 keyChar, RGFW_keymod keyMod, RGFW_bool pressed) {
     if (key == RGFW_escape && pressed) {
         RGFW_window_setShouldClose(win, 1);
     }
@@ -77,9 +77,9 @@ int main() {
 
         // You can use modern OpenGL techniques, but this method is more straightforward for drawing just one triangle.
         glBegin(GL_TRIANGLES);
-        glColor3f(1, 0, 0); glVertex2f(-0.6, -0.75);
-        glColor3f(0, 1, 0); glVertex2f(0.6, -0.75);
-        glColor3f(0, 0, 1); glVertex2f(0, 0.75);
+        glColor3f(1.0f, 0.0f, 0.0f); glVertex2f(-0.6f, -0.75f);
+        glColor3f(0.0f, 1.0f, 0.0f); glVertex2f(0.6f, -0.75f);
+        glColor3f(0.0f, 0.0f, 1.0f); glVertex2f(0.0f, 0.75f);
         glEnd();
 
         RGFW_window_swapBuffers(win);

--- a/RGFW.h
+++ b/RGFW.h
@@ -101,7 +101,7 @@ int main() {
 
 		RGFW_window_swapBuffers(win);
 
-		glClearColor(1, 1, 1, 1);
+		glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
 	}
 

--- a/examples/custom-backend/custom-backend.c
+++ b/examples/custom-backend/custom-backend.c
@@ -3,7 +3,7 @@
 #include "RGFW_SDL_example.h"
 #include <stdio.h>
 
-void keyfunc(RGFW_window* win, RGFW_key key, char keyChar, RGFW_keymod keyMod, b8 pressed) {
+void keyfunc(RGFW_window* win, RGFW_key key, u8 keyChar, RGFW_keymod keyMod, b8 pressed) {
     if (key == RGFW_escape && pressed) {
         RGFW_window_setShouldClose(win, 1);
     }
@@ -35,9 +35,9 @@ int main() {
 
         // You can use modern OpenGL techniques, but this method is more straightforward for drawing just one triangle.
         glBegin(GL_TRIANGLES);
-        glColor3f(1, 0, 0); glVertex2f(-0.6, -0.75);
-        glColor3f(0, 1, 0); glVertex2f(0.6, -0.75);
-        glColor3f(0, 0, 1); glVertex2f(0, 0.75);
+        glColor3f(1.0f, 0.0f, 0.0f); glVertex2f(-0.6f, -0.75f);
+        glColor3f(0.0f, 1.0f, 0.0f); glVertex2f(0.6f, -0.75f);
+        glColor3f(0.0f, 0.0f, 1.0f); glVertex2f(0.0f, 0.75f);
         glEnd();
 
         RGFW_window_swapBuffers(win);

--- a/examples/gamepad/gamepad.c
+++ b/examples/gamepad/gamepad.c
@@ -79,7 +79,7 @@ void drawRect(int cx, int cy, int width, int height, RGFW_window* w) {
         glVertex2f(RFONT_GET_WORLD(cx + width, cy + height));
         glVertex2f(RFONT_GET_WORLD(cx + width, cy));
     glEnd();
-    glColor3f(0.3, 0.3, 0.3);
+    glColor3f(0.3f, 0.3f, 0.3f);
 }
 
 
@@ -107,16 +107,16 @@ void drawLine(int cx, int cy, int x2, int y2, RGFW_window* w) {
 
 void colorIfPressed(RGFW_window* win, size_t gamepad, u32 button) {
     if (RGFW_isPressedGamepad(win, gamepad, button))
-        glColor3f(0.8, 0, 0);
+        glColor3f(0.8f, 0.0f, 0.0f);
     else 
-        glColor3f(0.3, 0.3, 0.3);
+        glColor3f(0.3f, 0.3f, 0.3f);
 }
 
 void drawGamepad(RGFW_window* w, size_t gamepad) {
     glClear(GL_COLOR_BUFFER_BIT);
-    glClearColor(0.8, 0.8, 0.8, 1.0);  
+    glClearColor(0.8f, 0.8f, 0.8f, 1.0f);  
 
-    glColor3f(0.00, 0.00, 0.00);
+    glColor3f(0.0f, 0.0f, 0.0f);
     if (gamepad == 3) {
         RGFW_rect r = {w->r.w - 100 + 20, w->r.h - 100, 50, 80};
         drawRect(r.x - 20, r.y, 2, r.h, w);
@@ -128,7 +128,7 @@ void drawGamepad(RGFW_window* w, size_t gamepad) {
             drawRect(w->r.w - 100 + (i * 20), w->r.h - 100, 2, 80, w);
     }
 
-    glColor3f(0.05, 0.05, 0.05);
+    glColor3f(0.05f, 0.05f, 0.05f);
 
     #ifndef __EMSCRIPTEN__
     glBegin(GL_POLYGON);
@@ -145,7 +145,7 @@ void drawGamepad(RGFW_window* w, size_t gamepad) {
     drawRect(200, 45, 400, 300, w);
     #endif
 
-    glColor3f(0.3, 0.3, 0.3);
+    glColor3f(0.3f, 0.3f, 0.3f);
 
     colorIfPressed(w, gamepad, RGFW_gamepadStart);
     drawCircle(436, 150, 9, w);
@@ -184,26 +184,26 @@ void drawGamepad(RGFW_window* w, size_t gamepad) {
     RGFW_point rightStick = RGFW_getGamepadAxis(w, gamepad, 1);
 
     // Draw axis: left joystick
-    glColor3f(0.3, 0.3, 0.3);
+    glColor3f(0.3f, 0.3f, 0.3f);
     drawCircle(259, 152, 33, w);
-    glColor3f(0.2, 0.2, 0.2);
+    glColor3f(0.2f, 0.2f, 0.2f);
 
-    if (RGFW_isPressedGamepad(w, gamepad, RGFW_gamepadL3))  glColor3f(0.3, 0, 0);
-    else  glColor3f(0.2, 0.2, 0.2);
+    if (RGFW_isPressedGamepad(w, gamepad, RGFW_gamepadL3))  glColor3f(0.3f, 0.0f, 0.0f);
+    else  glColor3f(0.2f, 0.2f, 0.2f);
     drawCircle(259 + (int)(((float)leftStick.x / 100.0f) * 20),
                 152 + (int)(((float)leftStick.y / 100.0f) * 20), 25, w);
 
     // Draw axis: right joystick
-    glColor3f(0.3, 0.3, 0.3);
+    glColor3f(0.3f, 0.3f, 0.3f);
     drawCircle(461, 237, 33, w);
 
-    if (RGFW_isPressedGamepad(w, gamepad, RGFW_gamepadR3))  glColor3f(0.3, 0, 0);
-    else  glColor3f(0.2, 0.2, 0.2);
+    if (RGFW_isPressedGamepad(w, gamepad, RGFW_gamepadR3))  glColor3f(0.3f, 0.0f, 0.0f);
+    else  glColor3f(0.2f, 0.2f, 0.2f);
 
     drawCircle(461 + (int)(((float)rightStick.x / 100.0f) * 20),
                 237 + (int)(((float)rightStick.y / 100.0f) * 20), 25, w);
 
-    glColor3f(0.3, 0.3, 0.3);
+    glColor3f(0.3f, 0.3f, 0.3f);
 
     // Draw axis: left-right triggers
     colorIfPressed(w, gamepad, RGFW_gamepadL2);

--- a/examples/gles2/gles2.c
+++ b/examples/gles2/gles2.c
@@ -83,7 +83,7 @@ int main(void) {
     glBlendFunc(GL_ONE, GL_ONE);
 
     glViewport(0, 0, 500, 500);
-    glClearColor(0.0, 0.0, 0.0, 1.0);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
     float attribute_array[] =
         //  x     y  r  g  b

--- a/examples/microui_demo/renderer.c
+++ b/examples/microui_demo/renderer.c
@@ -167,7 +167,7 @@ void r_set_clip_rect(mu_Rect rect) {
 
 void r_clear(mu_Color clr) {
   flush();
-  glClearColor(clr.r / 255., clr.g / 255., clr.b / 255., clr.a / 255.);
+  glClearColor(clr.r / 255.0f, clr.g / 255.0f, clr.b / 255.0f, clr.a / 255.0f);
   glClear(GL_COLOR_BUFFER_BIT);
 }
 

--- a/examples/multi-window/multi-window.c
+++ b/examples/multi-window/multi-window.c
@@ -59,7 +59,7 @@ void* loop(void* _win) {
 			blue = (blue + 1) % 100;
 		}
 
-		glClearColor(0.0, 0.0, (float)blue * 0.01f, 1.0);
+		glClearColor(0.0f, 0.0f, (float)blue * 0.01f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 
 		glBegin(GL_TRIANGLES);

--- a/examples/osmesa_demo/osmesa_demo.c
+++ b/examples/osmesa_demo/osmesa_demo.c
@@ -42,14 +42,14 @@ int main(void) {
         RGFW_window_makeCurrent(win);
         
         glViewport(0, 0, win->r.w, win->r.h);
-        glClearColor(1, 1, 1, 1);
+        glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
 
         glClear(GL_COLOR_BUFFER_BIT);
         
         glBegin(GL_TRIANGLES);
-            glColor3f(1, 0, 0); glVertex2f(-0.6, -0.75);
-            glColor3f(0, 1, 0); glVertex2f(0.6, -0.75);
-            glColor3f(0, 0, 1); glVertex2f(0, 0.75);
+            glColor3f(1.0f, 0.0f, 0.0f); glVertex2f(-0.6f, -0.75f);
+            glColor3f(0.0f, 1.0f, 0.0f); glVertex2f(0.6f, -0.75f);
+            glColor3f(0.0f, 0.0f, 1.0f); glVertex2f(0.0f, 0.75f);
         glEnd();
 
         glFlush();


### PR DESCRIPTION
Corrects a callback signature mismatch in keyfunc by changing keyChar from char to u8, aligning it with the declared type in RGFW_keyfunc.

Normalizes all glColor3f and glClearColor calls to use explicit float literals (f suffix), eliminating silent double → float narrowing and ensuring consistent, type-correct OpenGL usage across the codebase.

These changes do not affect program behavior, but improve semantic correctness, portability, and warning suppression under strict compilers such as MSVC /W4.