### PR TITLE
RGFW internal rewrite/review

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,8 @@ Release:    RGFW 1.7.5-dev
 - Update Wayland | fix some bugs and compile errors
 - add `RGFW_enter`, `RGFW_printScreen` and `RGFW_pause` keycodes
 - add RGFW_window_opengl_isSoftware
+- add OPTIONAL advanced `RGFW_init` functions and give the user more OPTIONAL control of global vars 
+- remove internal OS Mesa support
 
 Release:    RGFW 1.7 (May 6, 2025)
 -----------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ ifneq ($(NO_GLES), 1)
 		./examples/gles2/gles2$(EXT)
 endif
 ifneq ($(NO_OSMESA), 1)
-		./examples/osmesa/osmesa$(EXT)
+		./examples/osmesa_demo/osmesa_demo$(EXT)
 endif
 ifneq ($(NO_VULKAN), 1)
 		./examples/vk10/vk10$(EXT)

--- a/RGFW.h
+++ b/RGFW.h
@@ -1659,7 +1659,8 @@ RGFW_debugfunc RGFW_setDebugCallback(RGFW_debugfunc func) {
 
 void RGFW_sendDebugInfo(RGFW_debugType type, RGFW_errorCode err, RGFW_debugContext ctx, const char* msg) {
 	if (RGFW_debugCallback) RGFW_debugCallback(type, err, ctx, msg);
-	#ifdef RGFW_DEBUG
+        
+    #ifdef RGFW_DEBUG
 	switch (type) {
 		case RGFW_typeInfo: printf("RGFW INFO (%i %i): %s", type, err, msg); break;
 		case RGFW_typeError: printf("RGFW DEBUG (%i %i): %s", type, err, msg); break;
@@ -4008,7 +4009,7 @@ static int RGFW_XErrorHandler(Display* display, XErrorEvent* ev) {
     char errorText[512];
     XGetErrorText(display, ev->error_code, errorText, sizeof(errorText));
     
-    char buf[512];
+    char buf[1024];
     snprintf(buf, sizeof(buf),  "[X Error] %s\n  Error code: %d\n  Request code: %d\n  Minor code: %d\n  Serial: %lu\n",
              errorText,
              ev->error_code,

--- a/RGFW.h
+++ b/RGFW.h
@@ -1548,6 +1548,9 @@ typedef struct {
 	RGFW_bool prev  : 1;
 } RGFW_keyState;
 
+struct __IOHIDDevice; 
+typedef struct __IOHIDDevice IOHIDDeviceRef;
+
 typedef struct RGFW_infoStruct {
     RGFW_window* root;
     RGFW_window* current;
@@ -9013,7 +9016,7 @@ i32 RGFW_initPlatform(void) {
 	si_func_to_SEL("NSWindow", performKeyEquivalent);
 
     if ((id)_RGFW->NSApp == NULL) {
-		NSApp = objc_msgSend_id((id)objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
+		_RGFW->NSApp = objc_msgSend_id((id)objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
 
 		((void (*)(id, SEL, NSUInteger))objc_msgSend)
 			((id)_RGFW->NSApp, sel_registerName("setActivationPolicy:"), NSApplicationActivationPolicyRegular);
@@ -9138,7 +9141,7 @@ RGFW_window* RGFW_createWindowPtr(const char* name, RGFW_rect rect, RGFW_windowF
 
 	objc_msgSend_void((id)_RGFW->NSApp, sel_registerName("finishLaunching"));
 	NSRetain(win->src.window);
-	NSRetain(NSApp);
+	NSRetain(_RGFW->NSApp);
 
 	RGFW_sendDebugInfo(RGFW_typeInfo, RGFW_infoWindow, RGFW_DEBUG_CTX(win, 0), "a new  window was created");
 	return win;
@@ -10438,7 +10441,7 @@ void EMSCRIPTEN_KEEPALIVE Emscripten_onDrop(size_t count) {
 }
 
 void RGFW_stopCheckEvents(void) {
-	_RGFW.stopCheckEvents_bool = RGFW_TRUE;
+	_RGFW->stopCheckEvents_bool = RGFW_TRUE;
 }
 
 void RGFW_window_eventWait(RGFW_window* win, i32 waitMS) {
@@ -10447,10 +10450,10 @@ void RGFW_window_eventWait(RGFW_window* win, i32 waitMS) {
 
 	u32 start = (u32)(((u64)RGFW_getTimeNS()) / 1e+6);
 
-	while ((_RGFW->eventLen == 0) && _RGFW.stopCheckEvents_bool == RGFW_FALSE && (RGFW_getTimeNS() / 1e+6) - start < waitMS)
+	while ((_RGFW->eventLen == 0) && _RGFW->stopCheckEvents_bool == RGFW_FALSE && (RGFW_getTimeNS() / 1e+6) - start < waitMS)
 		emscripten_sleep(0);
 
-	_RGFW.stopCheckEvents_bool = RGFW_FALSE;
+	_RGFW->stopCheckEvents_bool = RGFW_FALSE;
 }
 
 void RGFW_window_initBufferPtr(RGFW_window* win, u8* buffer, RGFW_area area){

--- a/RGFW.h
+++ b/RGFW.h
@@ -736,10 +736,12 @@ typedef struct RGFW_window_src {
 } RGFW_window_src;
 #elif defined(RGFW_WASM)
 typedef struct RGFW_window_src {
-	#if defined(RGFW_WEBGPU)
+    #if defined(RGFW_WEBGPU)
 		WGPUInstance ctx;
         WGPUDevice device;
         WGPUQueue queue;
+		EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx;
+	#else
 		EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx;
 	#endif
 } RGFW_window_src;
@@ -10453,7 +10455,7 @@ void RGFW_window_initOpenGL(RGFW_window* win) {
 #endif
 }
 
-void RGFW_window_freeOpenGL(RGFW_window* win) {
+void RGFW_window_freeOpenGL(RGFW_window* win) ?{
 #if defined(RGFW_OPENGL) && !defined(RGFW_WEBGPU) && !defined(RGFW_BUFFER) 
 	if (win->src.ctx == 0) return;
 	emscripten_webgl_destroy_context(win->src.ctx);

--- a/RGFW.h
+++ b/RGFW.h
@@ -1610,7 +1610,7 @@ typedef struct RGFW_infoStruct {
     
     #ifdef RGFW_MACOS
     void* NSApp;
-    IOHIDDeviceRef osxControllers[4] = {NULL};
+    IOHIDDeviceRef osxControllers[4];
     #endif
 } RGFW_infoStruct;
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -1610,7 +1610,7 @@ typedef struct RGFW_infoStruct {
     
     #ifdef RGFW_MACOS
     void* NSApp;
-    IOHIDDeviceRef _RGFW->osxControllers[4] = {NULL};
+    IOHIDDeviceRef osxControllers[4] = {NULL};
     #endif
 } RGFW_infoStruct;
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -1549,7 +1549,6 @@ typedef struct {
 } RGFW_keyState;
 
 struct __IOHIDDevice; 
-typedef struct __IOHIDDevice* IOHIDDeviceRef;
 
 typedef struct RGFW_info {
     RGFW_window* root;
@@ -1577,13 +1576,12 @@ typedef struct RGFW_info {
     RGFW_keyState mouseButtons[RGFW_mouseFinal];
     RGFW_keyState keyboard[RGFW_keyLast]; 
 
-
     RGFW_bool useWaylandBool;
     RGFW_bool stopCheckEvents_bool;
     u64 timerOffset;
 
     char* clipboard_data;
-
+    char droppedFiles[RGFW_MAX_PATH * RGFW_MAX_DROPS];
     #ifdef RGFW_X11
         Display* display;
         Window helperWindow;
@@ -1610,7 +1608,7 @@ typedef struct RGFW_info {
     
     #ifdef RGFW_MACOS
     void* NSApp;
-    IOHIDDeviceRef osxControllers[4];
+    __IOHIDDevice* osxControllers[4];
     #endif
 } RGFW_info;
 
@@ -2128,7 +2126,7 @@ void RGFW_window_basic_init(RGFW_window* win, RGFW_rect rect, RGFW_windowFlags f
 	win->_lastMousePoint.x = 0; 
 	win->_lastMousePoint.y = 0; 
 
-	win->event.droppedFiles = (char**)RGFW_ALLOC(RGFW_MAX_PATH * RGFW_MAX_DROPS);
+	win->event.droppedFiles = _RGFW->droppedFiles;
 	RGFW_ASSERT(win->event.droppedFiles != NULL);
      
     { 

--- a/RGFW.h
+++ b/RGFW.h
@@ -1581,7 +1581,7 @@ typedef struct RGFW_info {
     u64 timerOffset;
 
     char* clipboard_data;
-    char droppedFiles[RGFW_MAX_DROPS][RGFW_MAX_PATH];
+    char droppedFiles[RGFW_MAX_PATH * RGFW_MAX_DROPS];
     #ifdef RGFW_X11
         Display* display;
         Window helperWindow;
@@ -2127,6 +2127,12 @@ void RGFW_window_basic_init(RGFW_window* win, RGFW_rect rect, RGFW_windowFlags f
 	win->_lastMousePoint.y = 0; 
 
 	win->event.droppedFiles = (char**)_RGFW->droppedFiles;
+     
+    { 
+        u32 i;
+        for (i = 0; i < RGFW_MAX_DROPS; i++)
+		    win->event.droppedFiles[i] = (char*)(win->event.droppedFiles + RGFW_MAX_DROPS + (i * RGFW_MAX_PATH));
+    }
 }
 
 void RGFW_window_setFlags(RGFW_window* win, RGFW_windowFlags flags) {

--- a/RGFW.h
+++ b/RGFW.h
@@ -10455,7 +10455,7 @@ void RGFW_window_initOpenGL(RGFW_window* win) {
 #endif
 }
 
-void RGFW_window_freeOpenGL(RGFW_window* win) ?{
+void RGFW_window_freeOpenGL(RGFW_window* win) {
 #if defined(RGFW_OPENGL) && !defined(RGFW_WEBGPU) && !defined(RGFW_BUFFER) 
 	if (win->src.ctx == 0) return;
 	emscripten_webgl_destroy_context(win->src.ctx);

--- a/RGFW.h
+++ b/RGFW.h
@@ -740,7 +740,6 @@ typedef struct RGFW_window_src {
 		WGPUInstance ctx;
         WGPUDevice device;
         WGPUQueue queue;
-		EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx;
 	#else
 		EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx;
 	#endif

--- a/RGFW.h
+++ b/RGFW.h
@@ -1549,7 +1549,7 @@ typedef struct {
 } RGFW_keyState;
 
 struct __IOHIDDevice; 
-typedef struct __IOHIDDevice IOHIDDeviceRef;
+typedef struct __IOHIDDevice* IOHIDDeviceRef;
 
 typedef struct RGFW_infoStruct {
     RGFW_window* root;

--- a/RGFW.h
+++ b/RGFW.h
@@ -1581,7 +1581,7 @@ typedef struct RGFW_info {
     u64 timerOffset;
 
     char* clipboard_data;
-    char droppedFiles[RGFW_MAX_PATH * RGFW_MAX_DROPS];
+    char droppedFiles[RGFW_MAX_DROPS][RGFW_MAX_PATH];
     #ifdef RGFW_X11
         Display* display;
         Window helperWindow;
@@ -2126,14 +2126,7 @@ void RGFW_window_basic_init(RGFW_window* win, RGFW_rect rect, RGFW_windowFlags f
 	win->_lastMousePoint.x = 0; 
 	win->_lastMousePoint.y = 0; 
 
-	win->event.droppedFiles = _RGFW->droppedFiles;
-	RGFW_ASSERT(win->event.droppedFiles != NULL);
-     
-    { 
-        u32 i;
-        for (i = 0; i < RGFW_MAX_DROPS; i++)
-		    win->event.droppedFiles[i] = (char*)(win->event.droppedFiles + RGFW_MAX_DROPS + (i * RGFW_MAX_PATH));
-    }
+	win->event.droppedFiles = (char**)_RGFW->droppedFiles;
 }
 
 void RGFW_window_setFlags(RGFW_window* win, RGFW_windowFlags flags) {

--- a/RGFW.h
+++ b/RGFW.h
@@ -10453,7 +10453,7 @@ void RGFW_window_initOpenGL(RGFW_window* win) {
 #endif
 }
 
-void RGFW_window_freeOpenGL(RGFW_window* win) {?
+void RGFW_window_freeOpenGL(RGFW_window* win) {
 #if defined(RGFW_OPENGL) && !defined(RGFW_WEBGPU) && !defined(RGFW_BUFFER) 
 	if (win->src.ctx == 0) return;
 	emscripten_webgl_destroy_context(win->src.ctx);

--- a/RGFW.h
+++ b/RGFW.h
@@ -10453,8 +10453,8 @@ void RGFW_window_initOpenGL(RGFW_window* win) {
 #endif
 }
 
-void RGFW_window_freeOpenGL(RGFW_window* win) {
-#if defined(RGFW_OPENGL) && !defined(RGFW_WEBGPU) 
+void RGFW_window_freeOpenGL(RGFW_window* win) {?
+#if defined(RGFW_OPENGL) && !defined(RGFW_WEBGPU) && !defined(RGFW_BUFFER) 
 	if (win->src.ctx == 0) return;
 	emscripten_webgl_destroy_context(win->src.ctx);
 	win->src.ctx = 0;

--- a/RGFW.h
+++ b/RGFW.h
@@ -4018,7 +4018,7 @@ static int RGFW_XErrorHandler(Display* display, XErrorEvent* ev) {
 
 
     RGFW_sendDebugInfo(RGFW_typeError, RGFW_errX11, RGFW_DEBUG_CTX(NULL, ev->error_code), buf);
-    _RGFW->x10Error = ev; 
+    _RGFW->x11Error = ev; 
     return 0; 
 }
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -7803,7 +7803,6 @@ void RGFW_window_close(RGFW_window* win) {
     _RGFW->windowCount--;
 	if (_RGFW->windowCount == 0) RGFW_deinit(_RGFW);
 
-	RGFW_FREE(win->event.droppedFiles);
 	if ((win->_flags & RGFW_WINDOW_ALLOC)) {
 		RGFW_FREE(win);
         win = NULL;
@@ -9969,8 +9968,6 @@ void RGFW_window_close(RGFW_window* win) {
     RGFW_clipboard_switch(NULL);
     _RGFW->windowCount--;
     if (_RGFW->windowCount == 0) RGFW_deinit(_RGFW);
-
-	RGFW_FREE(win->event.droppedFiles);
 	if ((win->_flags & RGFW_WINDOW_ALLOC)) {
 		RGFW_FREE(win);
         win = NULL;
@@ -10795,7 +10792,6 @@ void RGFW_window_close(RGFW_window* win) {
     _RGFW->windowCount--;
     if (_RGFW->windowCount == 0) RGFW_deinit(_RGFW);
 
-	RGFW_FREE(win->event.droppedFiles);
 	if ((win->_flags & RGFW_WINDOW_ALLOC)) {
 	    RGFW_FREE(win);
         win = NULL;

--- a/RGFW.h
+++ b/RGFW.h
@@ -2126,7 +2126,7 @@ void RGFW_window_basic_init(RGFW_window* win, RGFW_rect rect, RGFW_windowFlags f
 	win->_lastMousePoint.x = 0; 
 	win->_lastMousePoint.y = 0; 
 
-	win->event.droppedFiles = (char**)_RGFW->droppedFiles;
+	win->event.droppedFiles = (char**)(void*)_RGFW->droppedFiles;
      
     { 
         u32 i;

--- a/examples/osmesa_demo/osmesa_demo.c
+++ b/examples/osmesa_demo/osmesa_demo.c
@@ -1,8 +1,17 @@
 #define RGFW_IMPLEMENTATION
 #define RGFW_PRINT_ERRORS
 #define RGFW_DEBUG
-#define RGFW_OSMESA
+#define RGFW_BUFFER
+
 #include "RGFW.h"
+
+#ifndef __APPLE__
+    #include <GL/osmesa.h>
+#else
+    #include <OpenGL/osmesa.h>
+#endif
+
+
 #include <stdio.h>
 
 RGFW_area screenSize;
@@ -31,8 +40,12 @@ void clear(RGFW_window* win, u8 color[4]) {
 int main(void) {
 	RGFW_setClassName("RGFW Basic");
 
-    RGFW_window* win = RGFW_createWindow("RGFW Example Window", RGFW_RECT(500, 500, 500, 500), RGFW_windowAllowDND | RGFW_windowCenter);
+    RGFW_window* win = RGFW_createWindow("RGFW Example Window", RGFW_RECT(500, 500, 500, 500), RGFW_windowAllowDND | RGFW_windowCenter | RGFW_windowNoResize);
     
+	OSMesaContext ctx = OSMesaCreateContext(OSMESA_RGBA, NULL);
+    OSMesaMakeCurrent(ctx, win->buffer, GL_UNSIGNED_BYTE, win->r.w, win->r.h);
+    OSMesaPixelStore(OSMESA_Y_UP, 0);
+
     RGFW_window_makeCurrent(win);
     screenSize = RGFW_getScreenSize();
   


### PR DESCRIPTION
change `RGFW_init(void)` to

```c
i32 RGFW_init_ptr(RGFW_infoStruct* info)
void RGFW_deinit_tr(RGFW_infoStruct* info);
```

So the user can input their pointer, wherever it may be. 

Move more globals to `RGFW_infoStruct` 

Make it so that if `RGFW_init` is not called, it uses an internal static pointer. 

Remove internal OS Mesa support