### PR TITLE
Fix window flags on Windows

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -6925,7 +6925,7 @@ RGFW_window* RGFW_createWindowPtr(const char* name, RGFW_rect rect, RGFW_windowF
 	RECT windowRect, clientRect;
 
 	if (!(flags & RGFW_windowNoBorder)) {
-		window_style |= WS_CAPTION | WS_SYSMENU | WS_BORDER | WS_MINIMIZEBOX | WS_THICKFRAME;
+		window_style |= WS_CAPTION | WS_SYSMENU | WS_BORDER | WS_MINIMIZEBOX;
 
 		if (!(flags & RGFW_windowNoResize))
 			window_style |= WS_SIZEBOX | WS_MAXIMIZEBOX;


### PR DESCRIPTION
RGFW added WS_THICKFRAME flag on Windows by default. MSDN says [(link)](https://learn.microsoft.com/en-us/windows/win32/winmsg/window-styles) that WS_THICKFRAME is the same as WS_SIZEBOX, which means that sizebox was always created, even in cases when RGFW_windowNoResize was specified.