### PR TITLE
Make RGFW_XErrorHandler available only if RGFW_X11 is defined

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -4000,6 +4000,7 @@ RGFW_UNUSED(win);
 }
 #endif
 
+#ifdef RGFW_X11
 static int RGFW_XErrorHandler(Display* display, XErrorEvent* ev) {
     char errorText[512];
     XGetErrorText(display, ev->error_code, errorText, sizeof(errorText));
@@ -4013,7 +4014,7 @@ static int RGFW_XErrorHandler(Display* display, XErrorEvent* ev) {
     _RGFW->x11Error = ev; 
     return 0; 
 }
-
+#endif
 
 i32 RGFW_initPlatform(void) {
     RGFW_GOTO_WAYLAND(1);


### PR DESCRIPTION
Using the flag `WAYLAND_ONLY=1` made RGFW not able to compile. This wraps RGFW_XErrorHandler with a definition block so that if RGFW_X11 is not defined the method will not be included.