### PR TITLE
Improving event queue system

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -2043,7 +2043,7 @@ void RGFW_deinit_ptr(RGFW_info* info) {
 
 
 void RGFW_eventQueuePush(RGFW_event event) {
-	assert(_RGFW->eventLen >= 0);
+	RGFW_ASSERT(_RGFW->eventLen >= 0);
 
 	if (_RGFW->eventLen >= RGFW_MAX_EVENTS) {
 		RGFW_sendDebugInfo(RGFW_typeError, RGFW_errEventQueue, RGFW_DEBUG_CTX(NULL, 0), "Event queue limit 'RGFW_MAX_EVENTS' has been reaeched.");
@@ -2055,7 +2055,7 @@ void RGFW_eventQueuePush(RGFW_event event) {
 }
 
 RGFW_event* RGFW_eventQueuePop(RGFW_window* win) {
-	assert(_RGFW->eventLen >= 0 && _RGFW->eventLen <= RGFW_MAX_EVENTS);
+	RGFW_ASSERT(_RGFW->eventLen >= 0 && _RGFW->eventLen <= RGFW_MAX_EVENTS);
 
     if (_RGFW->eventLen == 0) {
 		return NULL;


### PR DESCRIPTION
The logic behind the current event queue system is needlessly complicated due to the whole LIFO mechanism aspect of it. This pull request significantly improves the current code by not only simplifying it and making it more efficient, but by also adding an additional error for when the end of the maximum event count is reached instead of just silently failing.