### PR TITLE
extra resize event no longer created

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -3388,20 +3388,22 @@ void RGFW_wl_xdg_toplevel_configure_handler(void *data,
         if (win == NULL)
             return;
     }
-    // first configure
-    if (width <= 0 || height <= 0) {
-        width = win->src.r.w;
-        height = win->src.r.h;
-    }
 
-    RGFW_window_checkMode(win);
-   	if (width != win->src.r.w || height != win->src.r.h) {
-			win->src.r = win->r = RGFW_RECT(win->src.r.x, win->src.r.y, width, height);
+	enum xdg_toplevel_state* state;
+	wl_array_for_each(state, states) {
+		switch (*state) {
+			case XDG_TOPLEVEL_STATE_RESIZING:
+				RGFW_window_checkMode(win);
+				win->src.r = win->r = RGFW_RECT(win->src.r.x, win->src.r.y, width, height);
 
-			RGFW_eventQueuePushEx(e.type = RGFW_windowResized; e.point = RGFW_POINT(width, height); e._win = win);
-			RGFW_windowResizedCallback(win, win->r);
+				RGFW_eventQueuePushEx(e.type = RGFW_windowResized; e.point = RGFW_POINT(width, height); e._win = win);
+				RGFW_windowResizedCallback(win, win->r);
 
-			RGFW_window_resize(win, RGFW_AREA(width, height));
+				RGFW_window_resize(win, RGFW_AREA(width, height));
+			default:
+				break;
+		}
+
 	}
 
 	RGFW_UNUSED(data); RGFW_UNUSED(states);


### PR DESCRIPTION
Running the basic example, a resize event would be created when the window was first created. This behavior is unintended and could result in unexpected results if users relied on the event.