### PR TITLE
Implement RGFW_monitor support under Wayland

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -6045,11 +6045,10 @@ RGFW_monitor RGFW_XCreateMonitor(i32 screen) {
 #endif
 RGFW_monitor* RGFW_getMonitors(size_t* len) {
 	
-
+	RGFW_init();
 	RGFW_GOTO_WAYLAND(1);
 	#ifdef RGFW_X11
 	static RGFW_monitor monitors[7];
-    RGFW_init();
 
 	Display* display = _RGFW->display;
 	i32 max = ScreenCount(display);

--- a/RGFW.h
+++ b/RGFW.h
@@ -3604,7 +3604,8 @@ void RGFW_wl_global_registry_handler(void *data,
 	} else if (RGFW_STRNCMP(interface,"wl_seat", 8) == 0) {
 		win->src.seat = wl_registry_bind(registry, id, &wl_seat_interface, 1);
 		wl_seat_add_listener(win->src.seat, &seat_listener, NULL);
-	} else if (RGFW_STRNCMP(interface, "wl_ouput", 9) == 0) {
+	} else if (RGFW_STRNCMP(interface, "wl_output", 10) == 0) {
+		RGFW_PRINTF("Output set\n");
 		_RGFW->wl_output = wl_registry_bind(registry, id, &wl_output_interface, 4);
 	}
 }
@@ -5878,13 +5879,12 @@ static float XGetSystemContentDPI(Display* display, i32 screen) {
 }
 #endif
 
+#ifdef RGFW_X11
 RGFW_monitor RGFW_XCreateMonitor(i32 screen);
 RGFW_monitor RGFW_XCreateMonitor(i32 screen) {
 	RGFW_monitor monitor;
     RGFW_init();
 
-	RGFW_GOTO_WAYLAND(1);
-#ifdef RGFW_X11
     Display* display = _RGFW->display;
 
 	if (screen == -1) screen = DefaultScreen(display);
@@ -5958,14 +5958,8 @@ RGFW_monitor RGFW_XCreateMonitor(i32 screen) {
 
 	RGFW_sendDebugInfo(RGFW_typeInfo, RGFW_infoMonitor, RGFW_DEBUG_CTX_MON(monitor), "monitor found");
     return monitor;
-#endif
-#ifdef RGFW_WAYLAND
-RGFW_WAYLAND_LABEL  RGFW_UNUSED(screen);
-    RGFW_sendDebugInfo(RGFW_typeInfo, RGFW_infoMonitor, RGFW_DEBUG_CTX_MON(monitor), "monitor found");
-    return monitor;
-#endif
 }
-
+#endif
 RGFW_monitor* RGFW_getMonitors(size_t* len) {
 	static RGFW_monitor monitors[7];
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -1564,7 +1564,8 @@ typedef struct RGFW_info {
         struct xkb_keymap *keymap;
         struct xkb_state *xkb_state;
         struct zxdg_decoration_manager_v1 *decoration_manager;
-
+		struct wl_output* wl_output;
+		
         struct wl_cursor_theme* wl_cursor_theme;
         struct wl_surface* cursor_surface;
         struct wl_cursor_image* cursor_image;
@@ -3603,6 +3604,8 @@ void RGFW_wl_global_registry_handler(void *data,
 	} else if (RGFW_STRNCMP(interface,"wl_seat", 8) == 0) {
 		win->src.seat = wl_registry_bind(registry, id, &wl_seat_interface, 1);
 		wl_seat_add_listener(win->src.seat, &seat_listener, NULL);
+	} else if (RGFW_STRNCMP(interface, "wl_ouput", 9) == 0) {
+		_RGFW->wl_output = wl_registry_bind(registry, id, &wl_output_interface, 4);
 	}
 }
 
@@ -4355,6 +4358,15 @@ RGFW_window* RGFW_createWindowPtr(const char* name, RGFW_rect rect, RGFW_windowF
 
 	zxdg_toplevel_decoration_v1_add_listener(win->src.decoration, &xdg_decoration_listener, NULL);
 	wl_display_roundtrip(win->src.wl_display);
+
+	// static const struct wl_output_listener wl_ouput_listener = {
+	// 		.geometry = ,
+	// 		.mode = ,
+	// 		.done = ,
+	// 		.scale = ,
+	// 		.name = ,
+	// 		.description = 
+	// };
 
 	wl_surface_commit(win->src.surface);
 	RGFW_window_show(win);
@@ -6266,7 +6278,7 @@ void RGFW_window_close(RGFW_window* win) {
 				wl_surface_destroy(win->src.surface);
 				wl_compositor_destroy(win->src.compositor);
 				xdg_wm_base_destroy(win->src.xdg_wm_base);
-
+				wl_output_release(_RGFW->wl_output);
 			
 		RGFW_clipboard_switch(NULL);
 		_RGFW->windowCount--;


### PR DESCRIPTION
This is a work in progress to support RGFW_monitor under Wayland. Currently it can detect the number of monitors but running the basic example, there is a memory leak somewhere.

