### PR TITLE
More general OpenGL improvements

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -2754,7 +2754,7 @@ i32* RGFW_initFormatAttribs(void) {
 #endif
 
 
-void RGFW_window_initOpenGL(RGFW_window* win) {
+RGFW_bool RGFW_window_initOpenGL(RGFW_window* win) {
 #if defined(RGFW_LINK_EGL)
 	eglInitializeSource = (PFNEGLINITIALIZEPROC) eglGetProcAddress("eglInitialize");
 	eglGetConfigsSource = (PFNEGLGETCONFIGSPROC) eglGetProcAddress("eglGetConfigs");
@@ -2801,8 +2801,6 @@ void RGFW_window_initOpenGL(RGFW_window* win) {
     #endif
     #ifdef RGFW_X11
 		win->src.EGL_display = eglGetDisplay((EGLNativeDisplayType) win->src.display);
-    #else
-    {}
     #endif
     #if !defined(RGFW_WAYLAND) && !defined(RGFW_WINDOWS) && !defined(RGFW_X11)
         win->src.EGL_display = eglGetDisplay((EGLNativeDisplayType) win->src.display);
@@ -2914,12 +2912,14 @@ void RGFW_window_initOpenGL(RGFW_window* win) {
 
 	if (win->src.EGL_context == NULL) {
 		RGFW_sendDebugInfo(RGFW_typeError, RGFW_errEGLContext, RGFW_DEBUG_CTX(win, 0), "Failed to create an EGL context.");
-		return;
+		return RGFW_FALSE;
 	}
 
 	eglMakeCurrent(win->src.EGL_display, win->src.EGL_surface, win->src.EGL_surface, win->src.EGL_context);
 	eglSwapBuffers(win->src.EGL_display, win->src.EGL_surface);
 	RGFW_sendDebugInfo(RGFW_typeInfo, RGFW_infoOpenGL, RGFW_DEBUG_CTX(win, 0), "EGL context initalized.");
+
+	return RGFW_TRUE;
 }
 
 void RGFW_window_freeOpenGL(RGFW_window* win) {

--- a/RGFW.h
+++ b/RGFW.h
@@ -673,12 +673,12 @@ typedef struct RGFW_window_src {
 	struct wl_shm* shm;
 	struct wl_seat *seat;
 	u8* buffer;
-	#if defined(RGFW_EGL)
+	#ifdef RGFW_EGL
 		struct wl_egl_window* eglWindow;
 	#endif
 #endif /* RGFW_WAYLAND */
 
-	#if defined(RGFW_EGL)
+	#ifdef RGFW_EGL
 		EGLSurface EGL_surface;
 		EGLDisplay EGL_display;
 		EGLContext EGL_context;

--- a/RGFW.h
+++ b/RGFW.h
@@ -1868,11 +1868,13 @@ void RGFW_window_checkMode(RGFW_window* win) {
 no more event call back defines
 */
 
-#define SET_ATTRIB(a, v) { \
+#define SET_ATTRIB(a, v) do { \
     RGFW_ASSERT(((size_t) index + 1) < sizeof(attribs) / sizeof(attribs[0])); \
-    attribs[index++] = a; \
-    attribs[index++] = v; \
-}
+    attribs[index] = a; \
+	index += 1; \
+    attribs[index] = v; \
+	index += 1; \
+} while (0)
 
 /* RGFW_BIT(24) */
 #define RGFW_EVENT_QUIT 		RGFW_BIT(25) /* the window close button was pressed */
@@ -3791,7 +3793,7 @@ void RGFW_window_getVisual(RGFW_window* win) {
 RGFW_bool RGFW_window_initOpenGL(RGFW_window* win) {
 	/* NOTE(EimaMei): I'm not sure why this array has to be 9 in particular considering 
 	 * only the profile mask and versions are set. Should be resolved before merging. */
-	i32 context_attribs[9] = {
+	i32 attribs[9] = {
 		GLX_CONTEXT_PROFILE_MASK_ARB,       0,
 		/* GLX_CONTEXT_MAJOR_VERSION_ARB */ 0, 
 		/* GLX_CONTEXT_MINOR_VERSION_ARB */ 0, 
@@ -3799,20 +3801,20 @@ RGFW_bool RGFW_window_initOpenGL(RGFW_window* win) {
 	};
 
 	switch (RGFW_GL_HINTS[RGFW_glProfile]) {
-		case RGFW_glES:            context_attribs[1] = GLX_CONTEXT_ES_PROFILE_BIT_EXT; break;
-		case RGFW_glCompatibility: context_attribs[1] = GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB; break;
-		case RGFW_glCore:          context_attribs[1] = GLX_CONTEXT_CORE_PROFILE_BIT_ARB; break;
+		case RGFW_glES:            attribs[1] = GLX_CONTEXT_ES_PROFILE_BIT_EXT; break;
+		case RGFW_glCompatibility: attribs[1] = GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB; break;
+		case RGFW_glCore:          attribs[1] = GLX_CONTEXT_CORE_PROFILE_BIT_ARB; break;
 		default: {
 			RGFW_sendDebugInfo(RGFW_typeWarning, RGFW_errOpenGLContext, RGFW_DEBUG_CTX(win, 0), "Invalid 'RGFW_glProfile' value. Defaulting to 'RGFW_glCore'.");
-			context_attribs[1] = GLX_CONTEXT_CORE_PROFILE_BIT_ARB;
+			attribs[1] = GLX_CONTEXT_CORE_PROFILE_BIT_ARB;
 		}
 	}
 
 	if (RGFW_GL_HINTS[RGFW_glMinor] || RGFW_GL_HINTS[RGFW_glMajor]) {
-		context_attribs[2] = GLX_CONTEXT_MAJOR_VERSION_ARB;
-		context_attribs[3] = RGFW_GL_HINTS[RGFW_glMajor];
-		context_attribs[4] = GLX_CONTEXT_MINOR_VERSION_ARB;
-		context_attribs[5] = RGFW_GL_HINTS[RGFW_glMinor];
+		attribs[2] = GLX_CONTEXT_MAJOR_VERSION_ARB;
+		attribs[3] = RGFW_GL_HINTS[RGFW_glMajor];
+		attribs[4] = GLX_CONTEXT_MINOR_VERSION_ARB;
+		attribs[5] = RGFW_GL_HINTS[RGFW_glMinor];
 	}
 
 	GLXContext ctx = NULL;
@@ -3824,7 +3826,7 @@ RGFW_bool RGFW_window_initOpenGL(RGFW_window* win) {
 	glXCreateContextAttribsARBProc glXCreateContextAttribsARB = (glXCreateContextAttribsARBProc)glXGetProcAddressARB((GLubyte*)"glXCreateContextAttribsARB");
 	if (glXCreateContextAttribsARB != NULL) {
 		_RGFW->x11Error = NULL;
-		win->src.ctx = glXCreateContextAttribsARB(win->src.display, win->src.bestFbc, ctx, True, context_attribs);
+		win->src.ctx = glXCreateContextAttribsARB(win->src.display, win->src.bestFbc, ctx, True, attribs);
 		if (_RGFW->x11Error || win->src.ctx == NULL) {
 			RGFW_sendDebugInfo(RGFW_typeWarning, RGFW_errOpenGLContext, RGFW_DEBUG_CTX(win, 0), "Failed to create an OpenGL context with AttribsARB, loading a generic OpenGL context.");
 			win->src.ctx = glXCreateContext(win->src.display, &win->src.visual, ctx, True);
@@ -6557,7 +6559,7 @@ void RGFW_win32_loadOpenGLFuncs(HWND dummyWin) {
 }
 
 #if defined(RGFW_OPENGL) && !defined(RGFW_EGL)
-void RGFW_window_initOpenGL(RGFW_window* win) {
+RGFW_bool RGFW_window_initOpenGL(RGFW_window* win) {
 	PIXELFORMATDESCRIPTOR pfd;
 	pfd.nSize        = sizeof(PIXELFORMATDESCRIPTOR);
 	pfd.nVersion     = 1;
@@ -6612,19 +6614,19 @@ void RGFW_window_initOpenGL(RGFW_window* win) {
 	if (wglCreateContextAttribsARB != NULL) {
 		u32 index = 0;
 		/* NOTE(EimaMei): I'm also not sure why this array has to be 40. Random numbers, honestly. */
-		i32 context_attribs[40] = {
+		i32 attribs[40] = {
 			WGL_CONTEXT_PROFILE_MASK_ARB,       0,
 			/* GLX_CONTEXT_MAJOR_VERSION_ARB */ 0, 
 			/* GLX_CONTEXT_MINOR_VERSION_ARB */ 0,
 		};
 
 		switch (RGFW_GL_HINTS[RGFW_glProfile]) {
-			case RGFW_glES:            context_attribs[1] = WGL_CONTEXT_ES_PROFILE_BIT_EXT; break;
-			case RGFW_glCompatibility: context_attribs[1] = WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB; break;
-			case RGFW_glCore:          context_attribs[1] = WGL_CONTEXT_CORE_PROFILE_BIT_ARB; break;
+			case RGFW_glES:            attribs[1] = WGL_CONTEXT_ES_PROFILE_BIT_EXT; break;
+			case RGFW_glCompatibility: attribs[1] = WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB; break;
+			case RGFW_glCore:          attribs[1] = WGL_CONTEXT_CORE_PROFILE_BIT_ARB; break;
 			default: {
 				RGFW_sendDebugInfo(RGFW_typeWarning, RGFW_errOpenGLContext, RGFW_DEBUG_CTX(win, 0), "Invalid 'RGFW_glProfile' value. Defaulting to 'RGFW_glCore'.");
-				context_attribs[1] = WGL_CONTEXT_CORE_PROFILE_BIT_ARB;
+				attribs[1] = WGL_CONTEXT_CORE_PROFILE_BIT_ARB;
 			}
 		}
 
@@ -8474,11 +8476,11 @@ void RGFW_window_freeOpenGL(RGFW_window* win) {
 
 
 i32 RGFW_initPlatform(void) {
-	si_func_to_SEL_with_name("NSObject", "windowShouldClose", (void*)RGFW_OnClose);
+	class_addMethod(objc_getClass("NSObject"), sel_registerName("windowShouldClose:"), (IMP)onClose, 0);
 
 	/* NOTE(EimaMei): Fixes the 'Boop' sfx from constantly playing each time you click a key. Only a problem when running in the terminal. */
-	si_func_to_SEL("NSWindow", acceptsFirstResponder);
-	si_func_to_SEL("NSWindow", performKeyEquivalent);
+	class_addMethod(objc_getClass("WindowClass"), (IMP)acceptsFirstResponder, 0);
+	class_addMethod(objc_getClass("WindowClass"), (IMP)performKeyEquivalent, 0);
 
 	if ((id)_RGFW->NSApp == NULL) {
 		_RGFW->NSApp = objc_msgSend_id((id)objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
@@ -9936,9 +9938,9 @@ RGFW_bool RGFW_window_initOpenGL(RGFW_window* win) {
 
 	emscripten_webgl_init_context_attributes(&attrs);
 	win->src.ctx = emscripten_webgl_create_context("#canvas", &attrs);
-	if (win->src.ctx == NULL) {
+	if (win->src.ctx == 0) {
 		RGFW_sendDebugInfo(RGFW_typeError, RGFW_errEGLContext, RGFW_DEBUG_CTX(win, 0), "Failed to create a WebGL context.");
-		return;
+		return RGFW_FALSE;
 	}
 
 	emscripten_webgl_make_context_current(win->src.ctx);
@@ -9948,6 +9950,8 @@ RGFW_bool RGFW_window_initOpenGL(RGFW_window* win) {
 	EM_ASM("Module.useWebGL = true; GLImmediate.init();");
     #endif
 	RGFW_sendDebugInfo(RGFW_typeInfo, RGFW_infoOpenGL, RGFW_DEBUG_CTX(win, 0), "OpenGL context initalized.");
+
+	return RGFW_TRUE;
 }
 
 void RGFW_window_freeOpenGL(RGFW_window* win) {

--- a/RGFW.h
+++ b/RGFW.h
@@ -341,10 +341,6 @@ int main() {
 #ifdef __EMSCRIPTEN__
 	#define RGFW_WASM
 
-	#if !defined(RGFW_NO_API) && !defined(RGFW_WEBGPU)
-		#define RGFW_OPENGL
-	#endif
-
 	#ifdef RGFW_EGL
 		#undef RGFW_EGL
 	#endif
@@ -395,7 +391,7 @@ int main() {
 	#endif
 #endif
 
-#if !defined(RGFW_EGL) && !defined(RGFW_OPENGL) && !defined(RGFW_DIRECTX) && !defined(RGFW_BUFFER) && !defined(RGFW_NO_API)
+#if !defined(RGFW_EGL) && !defined(RGFW_OPENGL) && !defined(RGFW_DIRECTX) && !defined(RGFW_BUFFER) && !defined(RGFW_NO_API) && !defined(RGFW_WEBGPU)
 	#define RGFW_OPENGL
 #endif
 
@@ -648,7 +644,7 @@ typedef struct RGFW_window_src {
 	GC gc;
 	XVisualInfo visual;
 
-	#if (defined(RGFW_OPENGL)) && !defined(RGFW_EGL)
+	#if defined(RGFW_OPENGL) && !defined(RGFW_EGL)
 		GLXContext ctx; /*!< source graphics context */
         GLXFBConfig bestFbc;
 	#endif
@@ -682,7 +678,7 @@ typedef struct RGFW_window_src {
 	#endif
 #endif /* RGFW_WAYLAND */
 
-	#if defined(RGFW_EGL) && !defined(RGFW_OPENGL)
+	#if defined(RGFW_EGL)
 		EGLSurface EGL_surface;
 		EGLDisplay EGL_display;
 		EGLContext EGL_context;
@@ -708,9 +704,9 @@ typedef struct RGFW_window_src {
 #elif defined(RGFW_WASM)
 
 typedef struct RGFW_window_src {
-	#ifndef RGFW_WEBGPU
+	#if defined(RGFW_OPENGL)
 		EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx;
-	#else
+	#else defined(RGFW_WEBGPU)
 		WGPUInstance ctx;
 		WGPUDevice device;
 		WGPUQueue queue;
@@ -2198,7 +2194,7 @@ void RGFW_window_swapBuffers(RGFW_window* win) {
 	}
 	#endif
 	
-	#ifdef RGFW_OPENGL
+	#if defined(RGFW_OPENGL) && !defined(RGFW_EGL)
 	if (win->src.ctx) {
 		RGFW_window_swapBuffers_OpenGL(win);
 	}
@@ -8476,7 +8472,7 @@ void RGFW_window_freeOpenGL(RGFW_window* win) {
 
 
 i32 RGFW_initPlatform(void) {
-	class_addMethod(objc_getClass("NSObject"), sel_registerName("windowShouldClose:"), (IMP)onClose, 0);
+	class_addMethod(objc_getClass("NSObject"), sel_registerName("windowShouldClose:"), (IMP)RGFW_OnClose, 0);
 
 	/* NOTE(EimaMei): Fixes the 'Boop' sfx from constantly playing each time you click a key. Only a problem when running in the terminal. */
 	class_addMethod(objc_getClass("WindowClass"), (IMP)acceptsFirstResponder, 0);

--- a/RGFW.h
+++ b/RGFW.h
@@ -1210,6 +1210,7 @@ RGFWDEF RGFW_bool RGFW_extensionSupported(const char* extension, size_t len);	/*
 RGFWDEF RGFW_bool RGFW_extensionSupportedPlatform(const char* extension, size_t len);	/*!< check if whether the specified platform-specific API extension is supported by the current OpenGL or OpenGL ES context */
 
 #endif
+
 #ifdef RGFW_VULKAN
 	#if defined(RGFW_WAYLAND) && defined(RGFW_X11)
     	#define VK_USE_PLATFORM_WAYLAND_KHR
@@ -2951,14 +2952,13 @@ HMODULE RGFW_wgl_dll = NULL;
 #endif
 
 RGFW_proc RGFW_getProcAddress(const char* procname) {
-	#if defined(RGFW_WINDOWS)
-	RGFW_proc proc = (RGFW_proc) GetProcAddress(RGFW_wgl_dll, procname);
-
-		if (proc)
-			return proc;
+	#ifdef RGFW_WINDOWS
+	RGFW_proc proc = (RGFW_proc)GetProcAddress(RGFW_wgl_dll, procname);
+	if (proc)
+		return proc;
 	#endif
 
-	return (RGFW_proc) eglGetProcAddress(procname);
+	return (RGFW_proc)eglGetProcAddress(procname);
 }
 
 RGFW_bool RGFW_extensionSupportedPlatform(const char* extension, size_t len) {
@@ -10218,8 +10218,10 @@ RGFW_area RGFW_getScreenSize(void) {
 	return RGFW_AREA(RGFW_innerWidth(), RGFW_innerHeight());
 }
 
-RGFW_bool RGFW_extensionSupportedPlatform(const char* extension, size_t len) {
 #ifdef RGFW_OPENGL
+
+RGFW_bool RGFW_extensionSupportedPlatform(const char* extension, size_t len) {
+
     return EM_ASM_INT({
         var ext = UTF8ToString($0, $1);
         var canvas = document.querySelector('canvas');
@@ -10229,18 +10231,14 @@ RGFW_bool RGFW_extensionSupportedPlatform(const char* extension, size_t len) {
         var supported = gl.getSupportedExtensions();
         return supported && supported.includes(ext) ? 1 : 0;
     }, extension, len);
-#else
-    return RGFW_FALSE;
-#endif
 }
 
 RGFW_proc RGFW_getProcAddress(const char* procname) {
-#ifdef RGFW_OPENGL
     return (RGFW_proc)emscripten_webgl_get_proc_address(procname);
-#else
-    return NULL
-#endif
+
 }
+
+#endif
 
 void RGFW_sleep(u64 milisecond) {
 	emscripten_sleep(milisecond);

--- a/RGFW.h
+++ b/RGFW.h
@@ -706,7 +706,7 @@ typedef struct RGFW_window_src {
 typedef struct RGFW_window_src {
 	#if defined(RGFW_OPENGL)
 		EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx;
-	#else defined(RGFW_WEBGPU)
+	#elif defined(RGFW_WEBGPU)
 		WGPUInstance ctx;
 		WGPUDevice device;
 		WGPUQueue queue;
@@ -8475,8 +8475,8 @@ i32 RGFW_initPlatform(void) {
 	class_addMethod(objc_getClass("NSObject"), sel_registerName("windowShouldClose:"), (IMP)RGFW_OnClose, 0);
 
 	/* NOTE(EimaMei): Fixes the 'Boop' sfx from constantly playing each time you click a key. Only a problem when running in the terminal. */
-	class_addMethod(objc_getClass("WindowClass"), (IMP)acceptsFirstResponder, 0);
-	class_addMethod(objc_getClass("WindowClass"), (IMP)performKeyEquivalent, 0);
+	class_addMethod(objc_getClass("WindowClass"), sel_registerName("acceptsFirstResponder"), (IMP)acceptsFirstResponder, 0);
+	class_addMethod(objc_getClass("WindowClass"), sel_registerName("performKeyEquivalent"), (IMP)performKeyEquivalent, 0);
 
 	if ((id)_RGFW->NSApp == NULL) {
 		_RGFW->NSApp = objc_msgSend_id((id)objc_getClass("NSApplication"), sel_registerName("sharedApplication"));


### PR DESCRIPTION
Changes:
- Removed older comments/credit relating to me (I find them cringe).
- Fixed a bug where `RGFW_OPENGL` would always be initialized on Emscripten.
- `#if defined(RGFW_EGL)` -> `#ifdef RGFW_EGL`
- `EMSCRIPTEN_WEBGL_CONTEXT_HANDLE` is only defined when `RGFW_OPENGL` is enabled.
- `RGFW_window_initOpenGL` returns a boolean to indicate if an OpenGL context is successfully defined.
- Minor improvements to `SET_ATTRIB`.
- `RGFW_window_swapBuffers` now includes `if` checks to make sure not to swap buffers for contexts that have been freed or even not initialized (eg when using `RGFW_windowNoInitAPI`).
- spaces -> tabs in `RGFW_window_freeOpenGL`.
- fixed spacing in `RGFW_getProcAddress`.
- Reworked all versions of `RGFW_window_initOpenGL` with better formatting, error checking and spacing. Errors that do not return false have been turned into warnings.
- Made `RGFW_window_initOpenGL` and `RGFW_window_freeOpenGL` only implemented if `RGFW_OPENGL` is defined.
- `RGFW_window_initOpenGL` is only ran when `RGFW_OPENGL` is defined.
- Deleted unused Silicon code and replaced existing Silicon functions with Objective-C functions.
- Improved some spacing with Cocoa enums.
- Emscripten version of `RGFW_createWindowPtr` only initializes WebGPU and WebGL if `RGFW_windowNoInitAPI` isn't specified.
- Check `if ((win->_flags & RGFW_windowNoInitAPI) == 0) RGFW_window_freeOpenGL(win);` has been removed as it's useless (IF window src is initialized to zero by default, which I'm not sure about).

NOTES:
- egl example does not render on X11 Linux.
- There are multiple ARB arrays that use arbitrary array sizes (the ones I've seen are in Linux, Windows and EGL).