### PR TITLE
EGL request a opaque surface if transparency is not used under x11 and wayland

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -3037,12 +3037,31 @@ RGFW_glContext* RGFW_window_createContext_EGL(RGFW_window* win) {
 	#elif defined(RGFW_WINDOWS)
 		win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, (EGLNativeWindowType) win->src.window, NULL);
 	#elif defined(RGFW_WAYLAND)
-		if (_RGFW->useWaylandBool)
-			win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, (EGLNativeWindowType) win->src.ctx.eglWindow, NULL);
-		else
+		
+		if (_RGFW->useWaylandBool) {
+		
+			RGFW_bool opaque_extension_Found = RGFW_extensionSupportedPlatform_EGL("EGL_EXT_present_opaque", 23);
+			
+			EGLint surf_attribs[3] = {
+				0x31df, EGL_TRUE, // EGL_PRESENT_OPAQUE_EXT
+				EGL_NONE
+			};
+		
+			win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, 
+				(EGLNativeWindowType) win->src.ctx.eglWindow, (!(win->_flags & RGFW_windowTransparent) && opaque_extension_Found) ? surf_attribs : NULL);
+		} else
     #endif
     #ifdef RGFW_X11
-            win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, (EGLNativeWindowType) win->src.window, NULL);
+    
+		RGFW_bool opaque_extension_Found = RGFW_extensionSupportedPlatform_EGL("EGL_EXT_present_opaque", 23);
+			
+		EGLint surf_attribs[3] = {
+			0x31df, EGL_TRUE, // EGL_PRESENT_OPAQUE_EXT
+			EGL_NONE
+		};
+		
+        win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, 
+			(EGLNativeWindowType) win->src.window, (!(win->_flags & RGFW_windowTransparent) && opaque_extension_Found) ? surf_attribs : NULL);
     #else
     {}
     #endif

--- a/RGFW.h
+++ b/RGFW.h
@@ -3036,31 +3036,29 @@ RGFW_glContext* RGFW_window_createContext_EGL(RGFW_window* win) {
 		win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, (EGLNativeWindowType) layer, NULL);
 	#elif defined(RGFW_WINDOWS)
 		win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, (EGLNativeWindowType) win->src.window, NULL);
-	#elif defined(RGFW_WAYLAND) || defined(RGFW_X11)
-		
+	#elif defined(RGFW_WAYLAND)
+	
 		const char present_opaque_str[] = "EGL_EXT_present_opaque";
 		RGFW_bool opaque_extension_Found = RGFW_extensionSupportedPlatform_EGL(present_opaque_str, sizeof(present_opaque_str));
 		
 		#ifndef EGL_PRESENT_OPAQUE_EXT
 		#define EGL_PRESENT_OPAQUE_EXT 0x31df
 		#endif
+		
 		EGLint surf_attribs[3] = {
 			EGL_PRESENT_OPAQUE_EXT, EGL_TRUE,
 			EGL_NONE
 		};
 		
-		#if defined(RGFW_WAYLAND)
-		if (_RGFW->useWaylandBool) {
+		if (_RGFW->useWaylandBool)
 			win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, 
 				(EGLNativeWindowType) win->src.ctx.eglWindow, (!(win->_flags & RGFW_windowTransparent) && opaque_extension_Found) ? surf_attribs : NULL);
-		} else
-		#endif
-		#ifdef RGFW_X11
-			win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, 
-				(EGLNativeWindowType) win->src.window, (!(win->_flags & RGFW_windowTransparent) && opaque_extension_Found) ? surf_attribs : NULL);
-		#else
-		{}
-		#endif
+		else
+    #endif
+    #ifdef RGFW_X11
+            win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, (EGLNativeWindowType) win->src.window, NULL);
+    #else
+    {}
     #endif
     #if !defined(RGFW_X11) && !defined(RGFW_WAYLAND) && !defined(RGFW_MACOS)
 		win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, (EGLNativeWindowType) win->src.window, NULL);

--- a/RGFW.h
+++ b/RGFW.h
@@ -3037,11 +3037,15 @@ RGFW_glContext* RGFW_window_createContext_EGL(RGFW_window* win) {
 	#elif defined(RGFW_WINDOWS)
 		win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, (EGLNativeWindowType) win->src.window, NULL);
 	#elif defined(RGFW_WAYLAND) || defined(RGFW_X11)
-
-		RGFW_bool opaque_extension_Found = RGFW_extensionSupportedPlatform_EGL("EGL_EXT_present_opaque", 23);
 		
+		const char present_opaque_str[] = "EGL_EXT_present_opaque";
+		RGFW_bool opaque_extension_Found = RGFW_extensionSupportedPlatform_EGL(present_opaque_str, sizeof(present_opaque_str));
+		
+		#ifndef EGL_PRESENT_OPAQUE_EXT
+		#define EGL_PRESENT_OPAQUE_EXT 0x31df
+		#endif
 		EGLint surf_attribs[3] = {
-			0x31df, EGL_TRUE, // EGL_PRESENT_OPAQUE_EXT
+			EGL_PRESENT_OPAQUE_EXT, EGL_TRUE,
 			EGL_NONE
 		};
 		

--- a/RGFW.h
+++ b/RGFW.h
@@ -3036,34 +3036,27 @@ RGFW_glContext* RGFW_window_createContext_EGL(RGFW_window* win) {
 		win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, (EGLNativeWindowType) layer, NULL);
 	#elif defined(RGFW_WINDOWS)
 		win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, (EGLNativeWindowType) win->src.window, NULL);
-	#elif defined(RGFW_WAYLAND)
-		
-		if (_RGFW->useWaylandBool) {
-		
-			RGFW_bool opaque_extension_Found = RGFW_extensionSupportedPlatform_EGL("EGL_EXT_present_opaque", 23);
-			
-			EGLint surf_attribs[3] = {
-				0x31df, EGL_TRUE, // EGL_PRESENT_OPAQUE_EXT
-				EGL_NONE
-			};
-		
-			win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, 
-				(EGLNativeWindowType) win->src.ctx.eglWindow, (!(win->_flags & RGFW_windowTransparent) && opaque_extension_Found) ? surf_attribs : NULL);
-		} else
-    #endif
-    #ifdef RGFW_X11
-    
+	#elif defined(RGFW_WAYLAND) || defined(RGFW_X11)
+
 		RGFW_bool opaque_extension_Found = RGFW_extensionSupportedPlatform_EGL("EGL_EXT_present_opaque", 23);
-			
+		
 		EGLint surf_attribs[3] = {
 			0x31df, EGL_TRUE, // EGL_PRESENT_OPAQUE_EXT
 			EGL_NONE
 		};
 		
-        win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, 
-			(EGLNativeWindowType) win->src.window, (!(win->_flags & RGFW_windowTransparent) && opaque_extension_Found) ? surf_attribs : NULL);
-    #else
-    {}
+		#if defined(RGFW_WAYLAND)
+		if (_RGFW->useWaylandBool) {
+			win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, 
+				(EGLNativeWindowType) win->src.ctx.eglWindow, (!(win->_flags & RGFW_windowTransparent) && opaque_extension_Found) ? surf_attribs : NULL);
+		} else
+		#endif
+		#ifdef RGFW_X11
+			win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, 
+				(EGLNativeWindowType) win->src.window, (!(win->_flags & RGFW_windowTransparent) && opaque_extension_Found) ? surf_attribs : NULL);
+		#else
+		{}
+		#endif
     #endif
     #if !defined(RGFW_X11) && !defined(RGFW_WAYLAND) && !defined(RGFW_MACOS)
 		win->src.ctx.EGL_surface = RGFW_eglCreateWindowSurface(win->src.ctx.EGL_display, config, (EGLNativeWindowType) win->src.window, NULL);


### PR DESCRIPTION
use EGL_PRESENT_OPAQUE_EXT if present and only if RGFW_windowTransparent is not set. 
This will allow the compositors to skip the transparency blending step.

