### PR TITLE
Fix horizontal client area offset on Windows

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -1375,7 +1375,7 @@ RGFWDEF RGFW_info* RGFW_getInfo(void);
 	struct RGFW_window_src {
 		HWND window; /*!< source window */
 		HDC hdc; /*!< source HDC */
-		u32 hOffset; /*!< height offset for window */
+		RGFW_area offset; /*!< width and height offset for window */
 		HICON hIconSmall, hIconBig; /*!< source window icons */
 		RGFW_area maxSize, minSize, aspectRatio; /*!< for setting max/min resize (RGFW_WINDOWS) */
 		#ifdef RGFW_OPENGL
@@ -6938,8 +6938,8 @@ LRESULT CALLBACK WndProcW(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 				int newHeight = (int)(width / aspectRatio);
 				int newWidth = (int)(height * aspectRatio);
 
-				if (win->r.w > windowRect.right - windowRect.left ||
-					win->r.h > (i32)((u32)(windowRect.bottom - windowRect.top) - win->src.hOffset))
+				if (win->r.w > (i32)((u32)(windowRect.right - windowRect.left) - win->src.offset.w)  ||
+					win->r.h > (i32)((u32)(windowRect.bottom - windowRect.top) - win->src.offset.h))
 				{
 					if (newHeight > height) windowRect.right = windowRect.left + newWidth;
 					else windowRect.bottom = windowRect.top + newHeight;
@@ -6948,12 +6948,12 @@ LRESULT CALLBACK WndProcW(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					else windowRect.bottom = windowRect.top + newHeight;
 				}
 
-				RGFW_window_resize(win, RGFW_AREA((windowRect.right - windowRect.left),
-												(u32)(windowRect.bottom - windowRect.top) - (u32)win->src.hOffset));
+				RGFW_window_resize(win, RGFW_AREA((u32)(windowRect.right - windowRect.left) - (u32)win->src.offset.w,
+												(u32)(windowRect.bottom - windowRect.top) - (u32)win->src.offset.h));
 			}
 
-			win->r.w = windowRect.right -  windowRect.left;
-			win->r.h = (windowRect.bottom - windowRect.top) - (i32)win->src.hOffset;
+			win->r.w = (windowRect.right - windowRect.left) - (i32)win->src.offset.w;
+			win->r.h = (windowRect.bottom - windowRect.top) - (i32)win->src.offset.h;
 			RGFW_eventQueuePushEx(e.type = RGFW_windowResized; e._win = win);
 			RGFW_windowResizedCallback(win, win->r);
 			RGFW_window_checkMode(win);
@@ -6972,13 +6972,13 @@ LRESULT CALLBACK WndProcW(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		#endif
 		case WM_GETMINMAXINFO: {
 			MINMAXINFO* mmi = (MINMAXINFO*) lParam;
-			mmi->ptMinTrackSize.x = (LONG)win->src.minSize.w;
-			mmi->ptMinTrackSize.y = (LONG)(win->src.minSize.h + win->src.hOffset);
+			mmi->ptMinTrackSize.x = (LONG)(win->src.minSize.w + win->src.offset.w);
+			mmi->ptMinTrackSize.y = (LONG)(win->src.minSize.h + win->src.offset.h);
 			if (win->src.maxSize.w == 0 && win->src.maxSize.h == 0)
 				return DefWindowProcW(hWnd, message, wParam, lParam);
 
-			mmi->ptMaxTrackSize.x = (LONG)win->src.maxSize.w;
-			mmi->ptMaxTrackSize.y = (LONG)(win->src.maxSize.h + win->src.hOffset);
+			mmi->ptMaxTrackSize.x = (LONG)(win->src.maxSize.w + win->src.offset.w);
+			mmi->ptMaxTrackSize.y = (LONG)(win->src.maxSize.h + win->src.offset.h);
 			return DefWindowProcW(hWnd, message, wParam, lParam);
 		}
 		case WM_PAINT: {
@@ -7361,8 +7361,9 @@ RGFW_window* RGFW_createWindowPtr(const char* name, RGFW_rect rect, RGFW_windowF
 	RGFW_win32_loadOpenGLFuncs(dummyWin);
 	DestroyWindow(dummyWin);
 
-	win->src.hOffset = (u32)(windowRect.bottom - windowRect.top) - (u32)(clientRect.bottom - clientRect.top);
-	win->src.window = CreateWindowW(Class.lpszClassName, (wchar_t*)wide_name, window_style, win->r.x, win->r.y, win->r.w, win->r.h + (i32)win->src.hOffset, 0, 0, inh, 0);
+	win->src.offset.w = (u32)(windowRect.right - windowRect.left) - (u32)(clientRect.right - clientRect.left);
+	win->src.offset.h = (u32)(windowRect.bottom - windowRect.top) - (u32)(clientRect.bottom - clientRect.top);
+	win->src.window = CreateWindowW(Class.lpszClassName, (wchar_t*)wide_name, window_style, win->r.x, win->r.y, win->r.w + (i32)win->src.offset.w, win->r.h + (i32)win->src.offset.h, 0, 0, inh, 0);
 	SetPropW(win->src.window, L"RGFW", win);
 	RGFW_window_resize(win, RGFW_AREA(win->r.w, win->r.h)); /* so WM_GETMINMAXINFO gets called again */
 
@@ -7458,7 +7459,7 @@ void RGFW_window_setFullscreen(RGFW_window* win, RGFW_bool fullscreen) {
 
 	if (fullscreen == RGFW_FALSE) {
 		RGFW_window_setBorder(win, 1);
-		SetWindowPos(win->src.window, HWND_NOTOPMOST, win->_oldRect.x, win->_oldRect.y, win->_oldRect.w, win->_oldRect.h + (i32)win->src.hOffset,
+		SetWindowPos(win->src.window, HWND_NOTOPMOST, win->_oldRect.x, win->_oldRect.y, win->_oldRect.w + (i32)win->src.offset.w, win->_oldRect.h + (i32)win->src.offset.h,
 			 SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
 
 		win->_flags &= ~(u32)RGFW_windowFullscreen;
@@ -8131,7 +8132,7 @@ void RGFW_window_resize(RGFW_window* win, RGFW_area a) {
 
 	win->r.w = (i32)a.w;
 	win->r.h = (i32)a.h;
-	SetWindowPos(win->src.window, HWND_TOP, 0, 0, win->r.w, win->r.h + (i32)win->src.hOffset, SWP_NOMOVE);
+	SetWindowPos(win->src.window, HWND_TOP, 0, 0, win->r.w + (i32)win->src.offset.w, win->r.h + (i32)win->src.offset.h, SWP_NOMOVE);
 }
 
 


### PR DESCRIPTION
This PR resolves an issue on Windows where the window's client area width is smaller than the requested size. The discrepancy appears to be caused by additional window borders added by Windows. The horizontal and vertical offsets are now stored in an `RGFW_area`.
