### PR TITLE
Fix WGL context creation

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -2705,17 +2705,15 @@ void RGFW_moveToMacOSResourceDir(void) { }
 	/* renderer */ RGFW_glAccelerated \
 }
 
+const
+RGFW_glHints RGFW_globalHints_OpenGL_BAK = RGFW_DEFAULT_GL_HINTS;
 RGFW_glHints RGFW_globalHints_OpenGL_SRC = RGFW_DEFAULT_GL_HINTS;
 RGFW_glHints* RGFW_globalHints_OpenGL = &RGFW_globalHints_OpenGL_SRC;
 
 void RGFW_resetGlobalHints_OpenGL(void) {
-#if !defined(__cplusplus) || defined(RGFW_MACOS)
-	RGFW_globalHints_OpenGL_SRC = (RGFW_glHints)RGFW_DEFAULT_GL_HINTS;
-#else
-	RGFW_globalHints_OpenGL_SRC = RGFW_DEFAULT_GL_HINTS;
-#endif
+	RGFW_globalHints_OpenGL_SRC = RGFW_globalHints_OpenGL_BAK;
 }
-void RGFW_setGlobalHints_OpenGL(RGFW_glHints* hints) { RGFW_globalHints_OpenGL = hints;  }
+void RGFW_setGlobalHints_OpenGL(RGFW_glHints* hints) { RGFW_globalHints_OpenGL_SRC = *hints;  }
 RGFW_glHints* RGFW_getGlobalHints_OpenGL(void) { RGFW_init(); return RGFW_globalHints_OpenGL; }
 
 
@@ -7602,50 +7600,37 @@ RGFW_bool RGFW_window_createContextPtr_OpenGL(RGFW_window* win, RGFW_glContext* 
 	/* get pixel format, default to a basic pixel format */
 	int pixel_format = ChoosePixelFormat(win->src.hdc, &pfd);
 	if (wglChoosePixelFormatARB != NULL) {
-		i32 pixel_format_attribs[50];
-		RGFW_attribStack stack;
-		RGFW_attribStack_init(&stack, pixel_format_attribs, 50);
+		u32 index = 0;
+		i32 attribs[80];
 
-		RGFW_attribStack_pushAttribs(&stack, WGL_ACCELERATION_ARB, WGL_FULL_ACCELERATION_ARB);
-		RGFW_attribStack_pushAttribs(&stack, WGL_DRAW_TO_WINDOW_ARB, 1);
-		RGFW_attribStack_pushAttribs(&stack, WGL_PIXEL_TYPE_ARB, WGL_TYPE_RGBA_ARB);
-		RGFW_attribStack_pushAttribs(&stack, WGL_SUPPORT_OPENGL_ARB, 1);
-		RGFW_attribStack_pushAttribs(&stack, WGL_COLOR_BITS_ARB, 32);
-		RGFW_attribStack_pushAttribs(&stack, WGL_DOUBLE_BUFFER_ARB, 1);
-		RGFW_attribStack_pushAttribs(&stack, WGL_ALPHA_BITS_ARB, hints->alpha);
-		RGFW_attribStack_pushAttribs(&stack, WGL_DEPTH_BITS_ARB, hints->depth);
-		RGFW_attribStack_pushAttribs(&stack, WGL_STENCIL_BITS_ARB, hints->stencil);
-		RGFW_attribStack_pushAttribs(&stack, WGL_STEREO_ARB, hints->stereo);
-		RGFW_attribStack_pushAttribs(&stack, WGL_AUX_BUFFERS_ARB, hints->auxBuffers);
-		RGFW_attribStack_pushAttribs(&stack, WGL_RED_BITS_ARB, hints->red);
-		RGFW_attribStack_pushAttribs(&stack, WGL_GREEN_BITS_ARB, hints->blue);
-		RGFW_attribStack_pushAttribs(&stack, WGL_BLUE_BITS_ARB, hints->green);
-		RGFW_attribStack_pushAttribs(&stack, WGL_ACCUM_RED_BITS_ARB, hints->accumRed);
-		RGFW_attribStack_pushAttribs(&stack, WGL_ACCUM_GREEN_BITS_ARB, hints->accumBlue);
-		RGFW_attribStack_pushAttribs(&stack, WGL_ACCUM_BLUE_BITS_ARB, hints->accumGreen);
-		RGFW_attribStack_pushAttribs(&stack, WGL_ACCUM_ALPHA_BITS_ARB, hints->accumAlpha);
+		SET_ATTRIB(WGL_COVERAGE_SAMPLES_NV, hints->samples);
 
-		RGFW_attribStack_pushAttribs(&stack, WGL_COLORSPACE_SRGB_EXT, hints->sRGB);
-		RGFW_attribStack_pushAttribs(&stack, WGL_CONTEXT_OPENGL_NO_ERROR_ARB, hints->noError);
+		SET_ATTRIB(WGL_ACCELERATION_ARB, WGL_FULL_ACCELERATION_ARB);
+		SET_ATTRIB(WGL_DRAW_TO_WINDOW_ARB, 1);
+		SET_ATTRIB(WGL_PIXEL_TYPE_ARB, WGL_TYPE_RGBA_ARB);
+		SET_ATTRIB(WGL_SUPPORT_OPENGL_ARB, 1);
+		SET_ATTRIB(WGL_COLOR_BITS_ARB, 32);
+		SET_ATTRIB(WGL_DOUBLE_BUFFER_ARB, 1);
+		SET_ATTRIB(WGL_ALPHA_BITS_ARB, hints->alpha);
+		SET_ATTRIB(WGL_DEPTH_BITS_ARB, hints->depth);
+		SET_ATTRIB(WGL_STENCIL_BITS_ARB, hints->stencil);
+		SET_ATTRIB(WGL_STEREO_ARB, hints->stereo);
+		SET_ATTRIB(WGL_AUX_BUFFERS_ARB, hints->auxBuffers);
+		SET_ATTRIB(WGL_RED_BITS_ARB, hints->red);
+		SET_ATTRIB(WGL_GREEN_BITS_ARB, hints->green);
+		SET_ATTRIB(WGL_BLUE_BITS_ARB, hints->blue);
+		SET_ATTRIB(WGL_ACCUM_RED_BITS_ARB, hints->accumRed);
+		SET_ATTRIB(WGL_ACCUM_GREEN_BITS_ARB, hints->accumGreen);
+		SET_ATTRIB(WGL_ACCUM_BLUE_BITS_ARB, hints->accumBlue);
+		SET_ATTRIB(WGL_ACCUM_ALPHA_BITS_ARB, hints->accumAlpha);
+		SET_ATTRIB(WGL_COLORSPACE_SRGB_EXT, hints->sRGB);
+		SET_ATTRIB(WGL_CONTEXT_OPENGL_NO_ERROR_ARB, hints->noError);
 
-		if (hints->releaseBehavior == RGFW_glReleaseFlush) {
-			RGFW_attribStack_pushAttribs(&stack, 0x2097, WGL_CONTEXT_RELEASE_BEHAVIOR_FLUSH_ARB); // WGL_CONTEXT_RELEASE_BEHAVIOR_ARB
-		} else if (hints->releaseBehavior == RGFW_glReleaseNone) {
-			RGFW_attribStack_pushAttribs(&stack, 0x2097, 0x0000); // WGL_CONTEXT_RELEASE_BEHAVIOR_NONE_ARB
-		}
-
-		i32 flags = 0;
-		if (hints->debug) flags |= WGL_ACCESS_READ_WRITE_NV; // substitute for debug bit, not exact
-		if (hints->robustness) flags |= WGL_CONTEXT_ES_PROFILE_BIT_EXT; // robustness placeholder
-		RGFW_attribStack_pushAttribs(&stack, WGL_CONTEXT_FLAGS_ARB, flags);
-
-		RGFW_attribStack_pushAttribs(&stack, WGL_COVERAGE_SAMPLES_NV, hints->samples);
-
-		RGFW_attribStack_pushAttribs(&stack, 0, 0);
+		SET_ATTRIB(0, 0);
 
 		int new_pixel_format;
 		UINT num_formats;
-		wglChoosePixelFormatARB(win->src.hdc, pixel_format_attribs, 0, 1, &new_pixel_format, &num_formats);
+		wglChoosePixelFormatARB(win->src.hdc, attribs, 0, 1, &new_pixel_format, &num_formats);
 		if (!num_formats)
 			RGFW_sendDebugInfo(RGFW_typeError, RGFW_errOpenGLContext, "Failed to create a pixel format for WGL");
 		else pixel_format = new_pixel_format;
@@ -7659,7 +7644,7 @@ RGFW_bool RGFW_window_createContextPtr_OpenGL(RGFW_window* win, RGFW_glContext* 
 	if (wglCreateContextAttribsARB != NULL) {
 		/* create OpenGL/WGL context for the specified version */
 		u32 index = 0;
-		i32 attribs[40];
+		i32 attribs[80];
 
 		i32 mask = 0;
 		switch (hints->profile) {
@@ -7675,6 +7660,17 @@ RGFW_bool RGFW_window_createContextPtr_OpenGL(RGFW_window* win, RGFW_glContext* 
 			SET_ATTRIB(WGL_CONTEXT_MAJOR_VERSION_ARB, hints->major);
 			SET_ATTRIB(WGL_CONTEXT_MINOR_VERSION_ARB, hints->minor);
 		}
+
+		if (hints->releaseBehavior == RGFW_glReleaseFlush) {
+			SET_ATTRIB(0x2097, WGL_CONTEXT_RELEASE_BEHAVIOR_FLUSH_ARB); // WGL_CONTEXT_RELEASE_BEHAVIOR_ARB
+		} else if (hints->releaseBehavior == RGFW_glReleaseNone) {
+			SET_ATTRIB(0x2097, 0x0000); // WGL_CONTEXT_RELEASE_BEHAVIOR_NONE_ARB
+		}
+
+		i32 flags = 0;
+		if (hints->debug) flags |= WGL_ACCESS_READ_WRITE_NV; // substitute for debug bit, not exact
+		if (hints->robustness) flags |= WGL_CONTEXT_ES_PROFILE_BIT_EXT; // robustness placeholder
+		SET_ATTRIB(WGL_CONTEXT_FLAGS_ARB, flags);
 
 		SET_ATTRIB(0, 0);
 


### PR DESCRIPTION
Fixed WGL context creation (Win10, Intel HD Graphics). Also swapped wrong blue/green accum/bits. There is something fishy in RGFW_attribStack_pushAttribs on my setup (x64/vs2022). I've ended up using the ADD_ATTRIB() macro instead.