### PR TITLE
Support the xdg_toplevel_icon protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ ifeq ($(WAYLAND),1)
 	NO_GLES = 0
 	NO_EGL = 0
 	NO_OSMESA ?= 0
-	LIBS += -D RGFW_WAYLAND relative-pointer-unstable-v1-client-protocol.c xdg-decoration-unstable-v1.c xdg-shell.c -lwayland-cursor -lwayland-client -lxkbcommon  -lwayland-egl -lEGL
+	LIBS += -D RGFW_WAYLAND relative-pointer-unstable-v1-client-protocol.c xdg-decoration-unstable-v1.c xdg-toplevel-icon-v1.c xdg-shell.c -lwayland-cursor -lwayland-client -lxkbcommon  -lwayland-egl -lEGL
 	LINK_GL1 = -lEGL -lGL
 
 	# LIBS += -ldecor-0
@@ -385,6 +385,8 @@ ifeq ($(WAYLAND),1)
 	wayland-scanner client-header /usr/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml xdg-shell.h
 	wayland-scanner public-code /usr/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml xdg-shell.c
 	wayland-scanner client-header /usr/share/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml xdg-decoration-unstable-v1.h
+	wayland-scanner public-code /usr/share/wayland-protocols/staging/xdg-toplevel-icon/xdg-toplevel-icon-v1.xml xdg-toplevel-icon-v1.c
+	wayland-scanner client-header /usr/share/wayland-protocols/staging/xdg-toplevel-icon/xdg-toplevel-icon-v1.xml xdg-toplevel-icon-v1.h
 	wayland-scanner public-code /usr/share/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml xdg-decoration-unstable-v1.c
 	wayland-scanner client-header /usr/share/wayland-protocols/unstable/relative-pointer/relative-pointer-unstable-v1.xml relative-pointer-unstable-v1-client-protocol.h
 	wayland-scanner client-header /usr/share/wayland-protocols/unstable/relative-pointer/relative-pointer-unstable-v1.xml relative-pointer-unstable-v1-client-protocol.c

--- a/RGFW.h
+++ b/RGFW.h
@@ -6401,6 +6401,9 @@ void RGFW_deinitPlatform_Wayland(void) {
 		xdg_toplevel_icon_manager_v1_destroy(_RGFW->icon_manager);
 	}
 
+	if (_RGFW->icon != NULL) {
+		xdg_toplevel_icon_v1_destroy(_RGFW->icon);
+	}
 	wl_shm_destroy(_RGFW->shm);
 	wl_seat_release(_RGFW->seat);
 	xdg_wm_base_destroy(_RGFW->xdg_wm_base);

--- a/RGFW.h
+++ b/RGFW.h
@@ -6735,17 +6735,29 @@ void RGFW_FUNC(RGFW_window_setMousePassthrough) (RGFW_window* win, RGFW_bool pas
 #endif /* RGFW_NO_PASSTHROUGH */
 
 RGFW_bool RGFW_FUNC(RGFW_window_setIconEx) (RGFW_window* win, u8* data, i32 w, i32 h, RGFW_format format, RGFW_icon type) {
-	RGFW_ASSERT(win != NULL); RGFW_UNUSED(data); RGFW_UNUSED(type); RGFW_UNUSED(format);
-	if (_RGFW->icon_manager == NULL) return RGFW_FALSE;
+	RGFW_ASSERT(win != NULL); 
+	RGFW_ASSERT(w == h);
+	RGFW_UNUSED(type);
 
+	if (_RGFW->icon_manager == NULL) return RGFW_FALSE;
+	
 	if (_RGFW->icon) {
 		xdg_toplevel_icon_v1_destroy(_RGFW->icon);
+		_RGFW->icon = NULL;
 	}
 
-	// RGFW_surface *icon_surface = RGFW_createSurface(data, w, h, RGFW_formatBGR8);
+	
+	RGFW_surface* surface = RGFW_createSurface(data, w, h, format);
 
-	// _RGFW->icon = xdg_toplevel_icon_manager_v1_create_icon(_RGFW->icon_manager);
-	xdg_toplevel_icon_v1_add_buffer(_RGFW->icon, icon_surface->native.wl_buffer, 1);
+	RGFW_copyImageData(surface->native.buffer, w, RGFW_MIN(h, surface->h), surface->native.format, surface->data, surface->format);
+
+	_RGFW->icon = xdg_toplevel_icon_manager_v1_create_icon(_RGFW->icon_manager);
+	xdg_toplevel_icon_v1_add_buffer(_RGFW->icon, surface->native.wl_buffer, 1);
+	xdg_toplevel_icon_manager_v1_set_icon(_RGFW->icon_manager, win->src.xdg_toplevel, _RGFW->icon);
+
+	
+	
+	RGFW_surface_free(surface);
 	return RGFW_TRUE;
 }
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -1716,6 +1716,8 @@ struct RGFW_info {
         struct xkb_keymap *keymap;
         struct xkb_state *xkb_state;
         struct zxdg_decoration_manager_v1 *decoration_manager;
+        struct xdg_toplevel_icon_manager_v1 *icon_manager;
+        struct xdg_toplevel_icon_v1 *icon;
 		struct wl_keyboard* wl_keyboard;
 		struct wl_compositor* compositor;
 		struct xdg_wm_base* xdg_wm_base;
@@ -5912,6 +5914,7 @@ struct wl_surface* RGFW_window_getWindow_Wayland(RGFW_window* win) { return win-
 
 /* wayland global garbage (wayland bad, X11 is fine (ish) (not really)) */
 #include "xdg-shell.h"
+#include "xdg-toplevel-icon-v1.h"
 #include "xdg-decoration-unstable-v1.h"
 
 void RGFW_toggleWaylandMaximized(RGFW_window* win, RGFW_bool maximized);
@@ -6269,6 +6272,8 @@ void RGFW_wl_global_registry_handler(void* data, struct wl_registry *registry, u
 		RGFW->xdg_wm_base = wl_registry_bind(registry, id, &xdg_wm_base_interface, 1);
 	} else if (RGFW_STRNCMP(interface, zxdg_decoration_manager_v1_interface.name, 255) == 0) {
 		RGFW->decoration_manager = wl_registry_bind(registry, id, &zxdg_decoration_manager_v1_interface, 1);
+	} else if (RGFW_STRNCMP(interface, xdg_toplevel_icon_manager_v1_interface.name, 255) == 0) {
+		RGFW->icon_manager = wl_registry_bind(registry, id, &xdg_toplevel_icon_manager_v1_interface, 1);
     } else if (RGFW_STRNCMP(interface, "wl_shm", 7) == 0) {
         RGFW->shm = wl_registry_bind(registry, id, &wl_shm_interface, 1);
         wl_shm_add_listener(RGFW->shm, &shm_listener, RGFW);
@@ -6391,6 +6396,10 @@ void RGFW_deinitPlatform_Wayland(void) {
 	wl_registry_destroy(_RGFW->registry);
 	if (_RGFW->decoration_manager != NULL)
 		zxdg_decoration_manager_v1_destroy(_RGFW->decoration_manager);
+
+	if (_RGFW->icon_manager != NULL) {
+		xdg_toplevel_icon_manager_v1_destroy(_RGFW->icon_manager);
+	}
 
 	wl_shm_destroy(_RGFW->shm);
 	wl_seat_release(_RGFW->seat);
@@ -6550,6 +6559,10 @@ RGFW_window* RGFW_FUNC(RGFW_createWindowPlatform) (const char* name, RGFW_window
 		#endif
 	}
 
+	if (_RGFW->icon_manager != NULL) {
+		// set the default wayland icon
+		xdg_toplevel_icon_manager_v1_set_icon(_RGFW->icon_manager, win->src.xdg_toplevel, NULL);
+	}
 	wl_surface_commit(win->src.surface);
 	RGFW_window_show(win);
 
@@ -6722,8 +6735,18 @@ void RGFW_FUNC(RGFW_window_setMousePassthrough) (RGFW_window* win, RGFW_bool pas
 #endif /* RGFW_NO_PASSTHROUGH */
 
 RGFW_bool RGFW_FUNC(RGFW_window_setIconEx) (RGFW_window* win, u8* data, i32 w, i32 h, RGFW_format format, RGFW_icon type) {
-	RGFW_ASSERT(win != NULL); RGFW_UNUSED(data); RGFW_UNUSED(w); RGFW_UNUSED(h); RGFW_UNUSED(format); RGFW_UNUSED(type);
-	return RGFW_FALSE;
+	RGFW_ASSERT(win != NULL); RGFW_UNUSED(data); RGFW_UNUSED(type); RGFW_UNUSED(format);
+	if (_RGFW->icon_manager == NULL) return RGFW_FALSE;
+
+	if (_RGFW->icon) {
+		xdg_toplevel_icon_v1_destroy(_RGFW->icon);
+	}
+
+	// RGFW_surface *icon_surface = RGFW_createSurface(data, w, h, RGFW_formatBGR8);
+
+	// _RGFW->icon = xdg_toplevel_icon_manager_v1_create_icon(_RGFW->icon_manager);
+	xdg_toplevel_icon_v1_add_buffer(_RGFW->icon, icon_surface->native.wl_buffer, 1);
+	return RGFW_TRUE;
 }
 
 RGFW_mouse* RGFW_FUNC(RGFW_loadMouse)(u8* data, i32 w, i32 h, RGFW_format format) {


### PR DESCRIPTION
This allows users to set a window icon on wayland compositors that support it. 
Icon dimensions must be a square or else it defaults to the wayland icon.
There is an issue with transparency.