### PR TITLE
Wayland refractor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,6 @@ debug: all
 		.$(OS_DIR)$$exe$(EXT); \
 	done
 
-	./examples/icons/icons
 	./examples/gamepad/gamepad
 	./examples/first-person-camera/camera
 	./examples/portableGL/pgl$(EXT)

--- a/RGFW.h
+++ b/RGFW.h
@@ -2240,7 +2240,11 @@ RGFW_window* RGFW_createWindowPtr(const char* name, i32 x, i32 y, i32 w, i32 h, 
 		RGFW_window_show(win);
 	}
 
-	RGFW_sendDebugInfo(RGFW_typeInfo, RGFW_infoWindow, "a new  window was created");
+	RGFW_sendDebugInfo(RGFW_typeInfo, RGFW_infoWindow, "a new window was created");
+
+	
+	RGFW_pollEvents();
+	
 	return ret;
 }
 
@@ -7369,7 +7373,6 @@ RGFW_bool RGFW_FUNC(RGFW_monitor_requestMode) (RGFW_monitor mon, RGFW_monitorMod
 
 RGFW_monitor RGFW_FUNC(RGFW_window_getMonitor) (RGFW_window* win) {
 	RGFW_ASSERT(win);
-	RGFW_pollEvents();
     return win->src.active_monitor;
 }
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -6259,9 +6259,10 @@ static void RGFW_wl_relative_pointer_motion(void *data, struct zwp_relative_poin
 }
 
 static void RGFW_wl_pointer_locked(void *data, struct zwp_locked_pointer_v1 *zwp_locked_pointer_v1) {
-	RGFW_window *win = (RGFW_window*)data;
-
-	RGFW_info* RGFW = (RGFW_info*)zwp_locked_pointer_v1_get_user_data(zwp_locked_pointer_v1);
+	RGFW_UNUSED(zwp_locked_pointer_v1);
+	RGFW_info* RGFW = (RGFW_info*)data;
+	RGFW_window* win = RGFW->mouseOwner;
+	
 	win->internal.lastMouseX = win->w / 2;
 	win->internal.lastMouseY = win->h / 2;
 	zwp_locked_pointer_v1_set_cursor_position_hint(win->src.locked_pointer, wl_fixed_from_int((win->w / 2)), wl_fixed_from_int((win->h / 2)));
@@ -6973,8 +6974,7 @@ void RGFW_FUNC(RGFW_captureCursor) (RGFW_window* win) {
 			.unlocked = (void (*)(void *, struct zwp_locked_pointer_v1 *))RGFW_doNothing
 		};
 
-		zwp_locked_pointer_v1_set_user_data(win->src.locked_pointer, _RGFW);
-		zwp_locked_pointer_v1_add_listener(win->src.locked_pointer, &locked_listener, win);
+		zwp_locked_pointer_v1_add_listener(win->src.locked_pointer, &locked_listener, _RGFW);
 	}
 }
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -7090,19 +7090,7 @@ u8 RGFW_FUNC(RGFW_rgfwToKeyChar)(u32 key) {
 
 void RGFW_FUNC(RGFW_pollEvents) (void) {
 	RGFW_resetPrevState();
-	struct pollfd fds [] = { { wl_display_get_fd(_RGFW->wl_display), POLLIN, 0 } };
-	
-	while (wl_display_prepare_read(_RGFW->wl_display) != 0)
-		wl_display_dispatch_pending(_RGFW->wl_display);
-	
-	wl_display_flush(_RGFW->wl_display);
-	i32 result = poll(fds, 1, -1);
-
-	if (result == -1)
-		wl_display_cancel_read(_RGFW->wl_display);
-	else 
-		wl_display_read_events(_RGFW->wl_display);
-	wl_display_dispatch_pending(_RGFW->wl_display);
+	wl_display_roundtrip(_RGFW->wl_display);
 }
 
 void RGFW_FUNC(RGFW_window_move) (RGFW_window* win, i32 x, i32 y) {

--- a/RGFW.h
+++ b/RGFW.h
@@ -6651,7 +6651,7 @@ static void RGFW_wl_global_registry_handler(void* data, struct wl_registry *regi
 		RGFW->seat = wl_registry_bind(registry, id, &wl_seat_interface, 1);
 		wl_seat_add_listener(RGFW->seat, &seat_listener, RGFW);
 	} else if (RGFW_STRNCMP(interface, zxdg_output_manager_v1_interface.name, 255) == 0) {
-		_RGFW->xdg_output_manager = wl_registry_bind(registry, id, &zxdg_output_manager_v1_interface, 1);
+		RGFW->xdg_output_manager = wl_registry_bind(registry, id, &zxdg_output_manager_v1_interface, 1);
 	} else if (RGFW_STRNCMP(interface,"wl_output", 10) == 0) {
 		RGFW_wl_create_outputs(registry, id);
 	}

--- a/RGFW.h
+++ b/RGFW.h
@@ -7074,7 +7074,7 @@ RGFW_window* RGFW_FUNC(RGFW_createWindowPlatform) (const char* name, RGFW_window
 	}
 
 	wl_surface_commit(win->src.surface);
-
+	wl_display_roundtrip(_RGFW->wl_display);
 	RGFW_UNUSED(name);
 
 	return win;

--- a/RGFW.h
+++ b/RGFW.h
@@ -7074,7 +7074,7 @@ RGFW_window* RGFW_FUNC(RGFW_createWindowPlatform) (const char* name, RGFW_window
 	}
 	
 	RGFW_UNUSED(name);
-	RGFW_window_show(win);
+	wl_surface_commit(win->src.surface);
 
 	return win;
 }
@@ -7083,7 +7083,7 @@ RGFW_bool RGFW_FUNC(RGFW_getGlobalMouse) (i32* x, i32* y) {
 	RGFW_init();
 	if (x) *x = 0;
 	if (y) *y = 0;
-	return RGFW_TRUE;
+	return RGFW_FALSE;
 }
 
 u8 RGFW_FUNC(RGFW_rgfwToKeyChar)(u32 key) {

--- a/RGFW.h
+++ b/RGFW.h
@@ -6266,19 +6266,10 @@ static void RGFW_wl_pointer_locked(void *data, struct zwp_locked_pointer_v1 *zwp
 	wl_pointer_set_cursor(RGFW->wl_pointer, RGFW->mouse_enter_serial, NULL, 0, 0); // draw no cursor
 }
 
-static void RGFW_wl_pointer_enter(void* data, struct wl_pointer* pointer, u32 serial,
+static void RGFW_wl_pointer_enter(void* data, struct wl_pointer* pointer, u32 serial, 
 		struct wl_surface *surface, wl_fixed_t surface_x, wl_fixed_t surface_y) {
 	RGFW_info* RGFW = (RGFW_info*)data;
-	RGFW_UNUSED(pointer);
 	RGFW_window* win = (RGFW_window*)wl_surface_get_user_data(surface);
-
-	// set the cursor
-	if (win->src.using_custom_cursor) {
-		wl_pointer_set_cursor(pointer, serial, win->src.custom_cursor_surface, 0, 0);
-	}
-	else {
-		RGFW_window_setMouseDefault(win);
-	}
 
 	// save when the pointer is locked or using default cursor
 	RGFW->mouse_enter_serial = serial;
@@ -6287,6 +6278,15 @@ static void RGFW_wl_pointer_enter(void* data, struct wl_pointer* pointer, u32 se
 	RGFW->windowState.mouseEnter = RGFW_TRUE;
 
 	RGFW->mouseOwner = win;
+
+	// set the cursor
+	if (win->src.using_custom_cursor) {
+		wl_pointer_set_cursor(pointer, serial, win->src.custom_cursor_surface, 0, 0);
+	}
+	else {
+		RGFW_window_setMouseDefault(win);
+	}
+	
 	if (!(win->internal.enabledEvents & RGFW_mouseEnterFlag)) return;
 
 	i32 x = (i32)wl_fixed_to_double(surface_x);

--- a/RGFW.h
+++ b/RGFW.h
@@ -7026,7 +7026,7 @@ RGFW_window* RGFW_FUNC(RGFW_createWindowPlatform) (const char* name, RGFW_window
 		xdg_toplevel_icon_manager_v1_set_icon(_RGFW->icon_manager, win->src.xdg_toplevel, NULL);
 	}
 
-	RGFW_window_setName(win, name);
+	RGFW_UNUSED(name);
 	RGFW_window_show(win);
 	
 	// recieve all events needed to configure

--- a/RGFW.h
+++ b/RGFW.h
@@ -7023,21 +7023,18 @@ RGFW_window* RGFW_FUNC(RGFW_createWindowPlatform) (const char* name, RGFW_window
 		// set the default wayland icon
 		xdg_toplevel_icon_manager_v1_set_icon(_RGFW->icon_manager, win->src.xdg_toplevel, NULL);
 	}
-	wl_surface_commit(win->src.surface);
+
+	RGFW_window_setName(win, name);
 	RGFW_window_show(win);
-	wl_display_flush(_RGFW->wl_display);
-	wl_display_roundtrip(_RGFW->wl_display);
-	/* wait for the surface to be configured */
-	while (wl_display_dispatch_pending(_RGFW->wl_display) > 0) { }
-	wl_surface_commit(win->src.surface);
+	
+	// recieve all events needed to configure
+	wl_display_roundtrip(_RGFW->wl_display); 
 
 	#ifndef RGFW_NO_MONITOR
 	if (flags & RGFW_windowScaleToMonitor)
 		RGFW_window_scaleToMonitor(win);
 	#endif
-
-	RGFW_window_setName(win, name);
-
+	
 	return win;
 }
 
@@ -7350,7 +7347,6 @@ RGFW_bool RGFW_FUNC(RGFW_monitor_requestMode) (RGFW_monitor mon, RGFW_monitorMod
 }
 
 RGFW_monitor RGFW_FUNC(RGFW_window_getMonitor) (RGFW_window* win) {
-	RGFW_pollEvents();
 	RGFW_ASSERT(win);
     return win->src.active_monitor;
 }

--- a/RGFW.h
+++ b/RGFW.h
@@ -6926,6 +6926,11 @@ void RGFW_FUNC(RGFW_surface_freePtr) (RGFW_surface* surface) {
 
 void RGFW_FUNC(RGFW_window_setBorder) (RGFW_window* win, RGFW_bool border) {
 	RGFW_setBit(&win->internal.flags, RGFW_windowNoBorder, !border);
+
+	// for now just toggle between SSD & CSD depending on the bool
+	if (_RGFW->decoration_manager != NULL) {
+		zxdg_toplevel_decoration_v1_set_mode(win->src.decoration, (border ? ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE : ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE));
+	}
 }
 
 void RGFW_FUNC(RGFW_releaseCursor) (RGFW_window* win) {
@@ -7067,7 +7072,7 @@ RGFW_window* RGFW_FUNC(RGFW_createWindowPlatform) (const char* name, RGFW_window
 		// set the default wayland icon
 		xdg_toplevel_icon_manager_v1_set_icon(_RGFW->icon_manager, win->src.xdg_toplevel, NULL);
 	}
-
+	
 	RGFW_UNUSED(name);
 	RGFW_window_show(win);
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -6659,7 +6659,8 @@ static void RGFW_wl_global_registry_handler(void* data, struct wl_registry *regi
 
 static void RGFW_wl_global_registry_remove(void* data, struct wl_registry *registry, u32 id) {
 	RGFW_UNUSED(data); RGFW_UNUSED(registry);
-	RGFW_monitorNode* prev = _RGFW->monitors.list.head;
+	RGFW_info* RGFW = (RGFW_info*)data;
+	RGFW_monitorNode* prev = RGFW->monitors.list.head;
 	RGFW_monitorNode* node = NULL;
 	if (prev == NULL) return;
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -7093,7 +7093,11 @@ u8 RGFW_FUNC(RGFW_rgfwToKeyChar)(u32 key) {
 
 void RGFW_FUNC(RGFW_pollEvents) (void) {
 	RGFW_resetPrevState();
+
+	// send buffered requests to compositor
 	while (wl_display_flush(_RGFW->wl_display) == -1) {
+		// compositor not responding to new requests
+		// so let's dispatch some events so the compositor responds
 		if (errno == EAGAIN) {
 			if (wl_display_dispatch_pending(_RGFW->wl_display) == -1) {
 				return;
@@ -7102,7 +7106,9 @@ void RGFW_FUNC(RGFW_pollEvents) (void) {
 			return;
 		}
 	}
-	
+
+	// read the events; if empty this reads from the
+	// wayland file descriptor
 	if (wl_display_dispatch(_RGFW->wl_display) == -1) {
 		return;
 	}

--- a/RGFW.h
+++ b/RGFW.h
@@ -7074,7 +7074,9 @@ RGFW_window* RGFW_FUNC(RGFW_createWindowPlatform) (const char* name, RGFW_window
 	}
 
 	wl_surface_commit(win->src.surface);
-	wl_display_roundtrip(_RGFW->wl_display);
+	wl_display_dispatch(_RGFW->wl_display);
+	wl_surface_commit(win->src.surface);
+	
 	RGFW_UNUSED(name);
 
 	return win;

--- a/RGFW.h
+++ b/RGFW.h
@@ -7027,7 +7027,7 @@ RGFW_window* RGFW_FUNC(RGFW_createWindowPlatform) (const char* name, RGFW_window
 			decoration_mode = ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE;
 		}
 
-		zxdg_toplevel_decoration_v1_set_mode(win->src.decoration, win->src.decoration_mode);
+		zxdg_toplevel_decoration_v1_set_mode(win->src.decoration, decoration_mode);
 
 	// no xdg_decoration support	
 	} else if (!(flags & RGFW_windowNoBorder)) {

--- a/RGFW.h
+++ b/RGFW.h
@@ -7119,8 +7119,6 @@ RGFW_window* RGFW_FUNC(RGFW_createWindowPlatform) (const char* name, RGFW_window
 
 	wl_surface_commit(win->src.surface);
 	wl_display_dispatch(_RGFW->wl_display);
-	wl_surface_commit(win->src.surface);
-	
 	RGFW_UNUSED(name);
 
 	return win;

--- a/TODO
+++ b/TODO
@@ -1,5 +1,10 @@
 - look into using a single X11 display rather than one display per window
-- update wayland support (wayland is sus)
+- update wayland support
+  - clipboard
+  - drag n drop
+  - pointer warp
+  - transparency configuration
+  - return false on some global functions
 - ablity to create an RGFW window from an existing window 
 - Xrandr reporting unused monitor as the window's monitor 
 

--- a/examples/multi-window/multi-window.c
+++ b/examples/multi-window/multi-window.c
@@ -44,8 +44,8 @@ void checkEvents(RGFW_window* win) {
 				RGFW_window_setShouldClose(win, 1);
 				break;
 			case RGFW_windowResized:
-				if (event.mouse.x != 0 && event.mouse.y != 0)
-					printf("window %p: resize: %dx%d\n", (void*)win, event.mouse.x, event.mouse.y);
+				if (event.common.win->w != 0 && event.common.win->h)
+					printf("window %p: resize: %dx%d\n", (void*)win, event.common.win->w, event.common.win->h);
 				break;
 			case RGFW_dataDrop:
 				printf("window %p: drag and drop: %dx%d:\n", (void*)win, event.mouse.x, event.mouse.y);


### PR DESCRIPTION
- change the defines and if statement for srgb. 
- allow wayland windows to know which monitor the window is on. 
- For pointer and keyboard use the passed in rgfw_info and not the global current. 
- reduce the number of calls to create and configure a surface as some functions called the same code. 
- rework poll event for wayland
- implement set border