### PR TITLE
fix example program

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -86,7 +86,7 @@ int main() {
 	RGFW_event event;
 
 	RGFW_window_setExitKey(win, RGFW_escape);
-	RGFW_window_setIcon(win, icon, 3, 3, RGFW_formatRGBA);
+	RGFW_window_setIcon(win, icon, 3, 3, RGFW_formatRGBA8);
 
 	while (RGFW_window_shouldClose(win) == RGFW_FALSE) {
 		while (RGFW_window_checkEvent(win, &event)) {


### PR DESCRIPTION
The example program at the beginning of the `RGFW.h` header
does not compile and contains logic flaws. This pull request fixes
them.

Specifically, the original example uses the function
`RGFW_window_window_isKeyPressed` in line 92 which does not
exist. This could be fixed with `RGFW_window_isKeyPressed(win,
RGFW_escape)`.

However, when the escape key is pressed, the inner
while loop breaks but the outer loop continues since the exit key
was never set. For this reason, `RGFW_window_setExitKey(win, RGFW_escape)`
was added and `RGFW_window_isKeyPressed` has been removed.

The pixel format was updated from the old name `RGFW_formatRGBA`
to `RGFW_formatRGBA8`.

Lastly, mixed tabs and spaces have been replaced with only tabs to
be consistent with the rest of the example.