### PR TITLE
Fix double close event

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -6248,9 +6248,11 @@ static void RGFW_wl_xdg_toplevel_close_handler(void* data, struct xdg_toplevel *
 	RGFW_UNUSED(toplevel);
 	RGFW_window* win = (RGFW_window*)data;
 
-	RGFW_eventQueuePushEx(e.type = RGFW_quit; e.common.win = win);
-	RGFW_window_setShouldClose(win, RGFW_TRUE);
-	RGFW_windowQuitCallback(win);
+	if (!win->internal.shouldClose) {
+		RGFW_eventQueuePushEx(e.type = RGFW_quit; e.common.win = win);
+		RGFW_window_setShouldClose(win, RGFW_TRUE);
+		RGFW_windowQuitCallback(win);
+	}
 }
 
 static void RGFW_wl_xdg_decoration_configure_handler(void* data,

--- a/TODO
+++ b/TODO
@@ -5,6 +5,7 @@
   - pointer warp
   - transparency configuration
   - return false on some global functions
+  - support software rendering
 - ablity to create an RGFW window from an existing window 
 - Xrandr reporting unused monitor as the window's monitor 
 


### PR DESCRIPTION
match behavior with x11