### PR TITLE
Fix X11 events for raw mouse inputs and repeated key events, make event queue a queue

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -1726,12 +1726,13 @@ typedef struct {
 struct RGFW_info {
     RGFW_window* root;
     i32 windowCount;
-    i32 eventBottom;
-    i32 eventLen;
 
-    RGFW_mouse* hiddenMouse;
-    // A circular buffer (FIFO), using eventBottom/Len above
-    RGFW_event events[RGFW_MAX_EVENTS];
+	RGFW_mouse* hiddenMouse;
+
+    RGFW_event events[RGFW_MAX_EVENTS]; /* A circular buffer (FIFO), using eventBottom/Len  */
+
+	i32 eventBottom;
+    i32 eventLen;
 	RGFW_bool queueEvents;
 	RGFW_bool polledEvents;
 
@@ -4503,13 +4504,15 @@ void RGFW_XHandleEvent(void) {
 
 	event.common.win = win;
 
-	// Repeated key presses are sent as a release followed by another press at the same time.
-	// We want to convert that into a single key press event with the repeat flag set
+	/*
+		Repeated key presses are sent as a release followed by another press at the same time.
+		We want to convert that into a single key press event with the repeat flag set
+	*/
 	if (E.type == KeyRelease && XEventsQueued(_RGFW->display, QueuedAfterReading)) {
 		XEvent NE;
 		XPeekEvent(_RGFW->display, &NE);
 		if (NE.type == KeyPress && E.xkey.time == NE.xkey.time && E.xkey.keycode == NE.xkey.keycode) {
-			// Use the next event (the key press)
+			/* Use the next KeyPress event */
 			XNextEvent(_RGFW->display, &E);
 			event.key.repeat = RGFW_TRUE;
 		}


### PR DESCRIPTION
1. When the mouse is held (via `XGrabPointer`), duplicate events are sent. There are various links online when searching "XGrabPointer duplicate events" saying that this is due to the `owner_events` parameter being set to true. Setting it to false fixes these issues, though I had to also include the button events in the mask passed to `XGrabPointer` otherwise those weren't sent at all when the mouse was held.
2. The event queue was actually a LIFO (a stack) rather than a FIFI (a queue). If multiple events were queued my application would receive them in the opposite order that X11 sent them. I changed the implementation to use a circular buffer instead so it would be a FIFO. I left the behavior where it flushes when it's full in place, but it could easily be changed to just drop the event at the front of the queue instead.
3. A change a few months ago broke the repeated key events for X11 with an early return. With this change, you'll get events like this:
   1 `type=press, repeat=false`
   2  `type=press, repeat=true`
   3 `type=press, repeat=true`
   ...
   4  `type=release, repeat=false`
   Another option is to have similar behavior to GLFW, which has press, release, and repeat "actions" on a single key event type.

Besides the queue change, this only affects X11 behavior. I'm unable to test the other implementations, but they might not match this new X11 behavior (especially the repeated key events).

I'm happy to split this up into multiple PRs if you want.

Also, should this PR go to https://github.com/RSGL/RGFW-dev instead?