### PR TITLE
Fix compile error and assertion failure when RGFW_NO_X11_CURSOR is defined

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -6062,7 +6062,10 @@ void RGFW_deinitPlatform_X11(void) {
 		_RGFW->clipboard = NULL;
 	}
 
-    RGFW_freeMouse(_RGFW->hiddenMouse);
+	if (_RGFW->hiddenMouse) {
+		RGFW_freeMouse(_RGFW->hiddenMouse);
+		_RGFW->hiddenMouse = NULL;
+	}
 
     XDestroyWindow(_RGFW->display, (Drawable) _RGFW->helperWindow); /*!< close the window */
     XCloseDisplay(_RGFW->display); /*!< kill connection to the x server */


### PR DESCRIPTION
- Fixes compiler error when `RGFW_NO_X11_CURSOR` is defined on Linux. The variable `img` in `RGFW_loadMouse` is undefined in line 5288.
- Fixes assertion failure when `RGFW_NO_X11_CURSOR` is defined on Linux (and the above compiler error is fixed). In this scenario, calling `RGFW_freeMouse()` on a `NULL` argument (`_RGFW->hiddenMouse`) caused the assertion to fire.