### PR TITLE
Fixed the full-screen monitor setPosition in the Windows implementation.

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -9616,10 +9616,10 @@ void RGFW_window_setFullscreen(RGFW_window* win, RGFW_bool fullscreen) {
 	RGFW_monitor mon  = RGFW_window_getMonitor(win);
 	RGFW_window_setBorder(win, 0);
 
-    SetWindowPos(win->src.window, HWND_TOPMOST, 0, 0, (i32)mon.mode.w, (i32)mon.mode.h, SWP_NOOWNERZORDER | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+    SetWindowPos(win->src.window, HWND_TOPMOST, (i32)mon.x, (i32)mon.x, (i32)mon.mode.w, (i32)mon.mode.h, SWP_NOOWNERZORDER | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
     RGFW_monitor_scaleToWindow(mon, win);
 
-	win->x = 0; win->y = 0;
+	win->x = mon.x; win->y = mon.x;
 	win->w = mon.mode.w;
 	win->h = mon.mode.h;
 }
@@ -13707,3 +13707,4 @@ void RGFW_load_Wayland(void) {
 #if _MSC_VER
 	#pragma warning( pop )
 #endif
+


### PR DESCRIPTION
The window size was set correctly; however, the position was hardcoded to (0, 0). I changed this to the x and y coordinates of the monitor. This should save you a few hours of debugging if you're trying to set up full-screen mode for multiple windows.