### PR TITLE
fix issue with RGFW_window_swapInterval_OpenGL on X11

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -7078,7 +7078,7 @@ void RGFW_FUNC(RGFW_window_swapInterval_OpenGL) (RGFW_window* win, i32 swapInter
 	}
 
 	if (pfn != (PFNGLXSWAPINTERVALEXTPROC)1) {
-		pfn(_RGFW->display, win->src.window, swapInterval);
+		pfn(_RGFW->display, win->src.ctx.native->window, swapInterval);
 	}
 	else if (pfn2 != NULL) {
 		pfn2(swapInterval);


### PR DESCRIPTION
Hello,

Love the `1.8` version so far.

## Issue
i've updated from `RGFW 1.8.0-dev` -> `RGFW 1.8.0 pre-release` and since then the `RGFW_window_swapInterval_OpenGL` function does not disable vsync anymore. 

## Code snipped used
```c
    RGFW_glHints hints = {
        .major = 4, .minor = 3,
        .profile = RGFW_glCore,
    };
    RGFW_setGlobalHints_OpenGL(&hints);

    RGFW_window* window = RGFW_createWindow("BUG REPORT", 0, 0, 1080, 720, RGFW_windowOpenGL);

    RGFW_window_makeCurrentWindow_OpenGL(app.window);
    RGFW_window_swapInterval_OpenGL(app.window, 0); // <- does not turn off vsync
```

## My Fix
i noticed that `win->src.window` is not equal to `glXGetCurrentDrawable()`. in the `-dev` version it was. 

after checking `makeCurrentContext_OpenGL`, i saw that `win->src.ctx.native->window` is now passed as the drawable to `glXMakeCurrent` so tried using that value instead and it works.
```c
// this works
glXSwapInterval(_RGFW->display, win->src.ctx.native->window, swapInterval);
```

after further digging, i found that when `glXMakeCurrent` and `glXSwapInterval` are called with `win->src.window`, the swap interval function starts working again but only if `RGFW_window_makeCurrentWindow_OpenGL` is called before setting the swap interval:
```c
glXMakeCurrent(_RGFW->display, (Drawable)win->src.window, (GLXContext) win->src.ctx.native->ctx);
```
but using `win->src.ctx.native->window` for both `glXMakeCurrent` and `glXSwapIntervalEXT` works regardless of call order or context state.

## Confusion
why do `glXSwapInterval` and `glXMakeCurrent` both work when using `win->src.window`?
i also noticed that `win->src.window` and `win->src.ctx.native->window` both are of type `Window`, so i’m confused about the difference. should these two values always be the same?
