### PR TITLE
Repair hold/unhold mouse behavior on several platforms

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -12825,7 +12825,7 @@ EM_BOOL Emscripten_on_focusout(int eventType, const EmscriptenFocusEvent* E, voi
 
 	if ((_RGFW->root->internal.holdMouse)) {
 		RGFW_window_unholdMouse(_RGFW->root);
-		win->internal.holdMouse = RGFW_TRUE;
+		_RGFW->root->internal.holdMouse = RGFW_TRUE;
 		_RGFW->mouseOwner = _RGFW->root;
 	}
 


### PR DESCRIPTION
This patch began when I discovered a bug on the X backend: RGFW continues holding the cursor even after focus is lost, which makes the cursor unusable until the original program is terminated (with the mouse held and shown, this manifests as a 'sticky' mouse throughout the entire OS/WM). I fix this in the second commit.

However, when looking through the source, I discovered another potential bug: any window can 'recover' a held mouse, even if it isn't the window originally bound with RGFW_window_holdMouse. I resolved this in the first commit (on X) and tested it with the multi-window example.

I imagine this issue impacts other platforms as well. At this moment I can only test on X11. Speculatively, I implemented these fixes for wayland, macos, windows, and emscripten. The wayland and macos implementations were essentially identical. On emscripten, it looks like there may have been a separate bug where the held mouse was never recovered if the in focus event is ignored, so I resolved that as well. On windows, there was no logic to handle mouse holding at all (!) -- perhaps this behavior is unnecessary on that platform. This will need some review and testing on all the backends.