### PR TITLE
Repair fullscreen on X11

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -6044,9 +6044,9 @@ void RGFW_XHandleEvent(void) {
 			break;
 		}
 		case FocusIn:
-			if ((win->internal.flags & RGFW_windowFullscreen)) {
+			if ((win->internal.flags & RGFW_windowFullscreen))
 				RGFW_window_raise(win);
-			}
+
 			if ((win->internal.holdMouse)) RGFW_window_holdMouse(win);
 
 			if (!(win->internal.enabledEvents & RGFW_focusInFlag)) return;


### PR DESCRIPTION
This patch does a few things:

It fixes a bug on X11 where the `RGFW_windowFullscreen` flag is not respected. X11 requires this event to be sent after XMapWindow, but setFlagsInternal is called before XMapWindow. I opted to put this in `RGFW_window_show` considering that the user may hide the window at any point and make an arbitrary number of API calls before showing the window. But this does mean that the function is called twice. Alternatively, I believe in the X API it is possible to set the property on an unmapped window, but this requires different logic. Note that glfw doesn't do this. It's possible, though, if we went that way, fullscreen window launches may look cleaner on certain WMs. In any case, there might be a better path to resolving this issue.

It sets NET_WM_BYPASS_COMPOSITOR when targeting fullscreen on X11. This is desirable in general (or so I understand) and should improve performance for fullscreen apps. I did not test this change.

It reorders flag evaluation in `RGFW_setFlagsInternal`. This impacts all backends. This change makes it so that all window resize operations (including the borderless check) are performed before window centering. In retrospect, I see that maximize/minimize are not window scaling operations, but it seems clean to have them higher priority anyway. Open to any change here.