### PR TITLE
Remove RGFW_USE_INT in favor of the C-syle approach

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -168,6 +168,7 @@ int main() {
 		TheYahton (@TheYahton) -> documentation
 		nonexistant_object (@DiarrheaMcgee)
 		AC Gaudette (@acgaudette)
+		uint fixes (@ZDev22)
 */
 
 #if _MSC_VER


### PR DESCRIPTION
RGFW_USE_INT is supposed to be a way to allow older compilers to support RGFW, however there are a few major flaws.

It is pretty hidden away, meaning people compiling with older compilers most likely wont see it before it starts causing errors in their code. Granted, with the way this code is set up, it would be an easy fix, but still.

When using RGFW_USE_INT, stdint.h is never declared. While this most likely wont cause issues in most peoples code as they probably declared it (or maybe one of the other includes in the code has it), it causes issues because units are used a few times throughout the code without a RGFW_USE_INT check around them.

As RGFW tries to be minimal, I figured the best option was to remove RGFW_USE_INT all together and stick with the "Manually typing unsigned" approach. This also cleans up the code a little. If your goal was to make the code more readable with stdint, the option was already there to not use it anyways, so I figured trimming down the code base wouldn't hurt. This also makes RGFW just that slight bit easier to maintain and use :D

**PROBLEMS THIS MIGHT CAUSE**

Unfortunately to call functions that use these you would have to make the variables you are passing into them also that type. If the function takes a u8, your variable would have to be a u8. This might be an issue if the function takes a u32 or something and the variable you are passing into it must be signed for some other logic. There was probably a reason you decided to use units instead of your own typdefs, unless it was a minor oversight. (probably to be more compatible if you are switching from openGL) 

There are usually a lot of breaking changes in updates anyways, but I understand if it's not best to do this. I'm pretty sure that if your computer required this change before, it wouldn't have been able to compile the functions that were using units, so it may be worth just changing those?

I also don't have a out-in-the-wild opengl code base to test these changes on, so you may have to test it out over there. I personally doubt these changes would break too much stuff as it probably all compiles to the same anyways.

Honestly, the biggest hit to not doing this is the MSVC compiler before 2012, and a few compilers from the 1900's that basically no one uses anymore. This change may not be worth it just for those edge cases (even if compiling the program is a few microseconds faster lol) - this change does add more consistency to the code though