### PR TITLE
replace _RGFW != NULL with RGFW_ASSERT

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -3888,26 +3888,30 @@ void RGFW_resetPrevState(void) {
 }
 
 RGFW_bool RGFW_isKeyPressed(RGFW_key key) {
-    return _RGFW != NULL && _RGFW->keyboard[key].current && !_RGFW->keyboard[key].prev;
+	RGFW_ASSERT(_RGFW != NULL);
+    return _RGFW->keyboard[key].current && !_RGFW->keyboard[key].prev;
 }
-
 RGFW_bool RGFW_isKeyDown(RGFW_key key) {
-	return _RGFW != NULL && _RGFW->keyboard[key].current;
+	RGFW_ASSERT(_RGFW != NULL);
+	return _RGFW->keyboard[key].current;
 }
-
 RGFW_bool RGFW_isKeyReleased(RGFW_key key) {
-	return _RGFW != NULL && !_RGFW->keyboard[key].current && _RGFW->keyboard[key].prev;
+	RGFW_ASSERT(_RGFW != NULL);
+	return !_RGFW->keyboard[key].current && _RGFW->keyboard[key].prev;
 }
 
 
 RGFW_bool RGFW_isMousePressed(RGFW_mouseButton button) {
-	return _RGFW != NULL && _RGFW->mouseButtons[button].current && !_RGFW->mouseButtons[button].prev;
+	RGFW_ASSERT(_RGFW != NULL);
+	return _RGFW->mouseButtons[button].current && !_RGFW->mouseButtons[button].prev;
 }
 RGFW_bool RGFW_isMouseDown(RGFW_mouseButton button) {
-	return _RGFW != NULL && _RGFW->mouseButtons[button].current;
+	RGFW_ASSERT(_RGFW != NULL);
+	return _RGFW->mouseButtons[button].current;
 }
 RGFW_bool RGFW_isMouseReleased(RGFW_mouseButton button) {
-	return _RGFW != NULL && !_RGFW->mouseButtons[button].current && _RGFW->mouseButtons[button].prev;
+	RGFW_ASSERT(_RGFW != NULL);
+	return !_RGFW->mouseButtons[button].current && _RGFW->mouseButtons[button].prev;
 }
 
 void RGFW_getMouseScroll(float* x, float* y) {


### PR DESCRIPTION
this replaces the _RGFW != NULL check with RGFW_ASSERT(_RGFW != NULL) in the low-level keyboard/mouse functions.

this allows me to skip the check entirely by defining RGFW_ASSERT before including RGFW, as well as making it more readable