### PR TITLE
Small wayland fixes

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -8398,10 +8398,7 @@ static void RGFW_wl_xdg_surface_configure_handler(void* data, struct xdg_surface
 
 	if (win->src.resizing) {
 
-		/* Do not create a resize event if the window is maximized */
-		if (!win->src.maximized) {
-			RGFW_windowResizedCallback(win, win->w, win->h);
-		}
+		RGFW_windowResizedCallback(win, win->w, win->h);
 		RGFW_window_resize(win, win->w, win->h);
 		if (!(win->internal.flags & RGFW_windowTransparent)) {
 			RGFW_wl_setOpaque(win);


### PR DESCRIPTION
The pull request fixes two things. One being NULL pointer dereference when there is no such cursor available on the system. The second one, I removed `!win->src.maximized` check, because it was not sending resize events on DWL window manager. While I'm not sure about original intent of the check, I doubt it will break anything since window wouldn't send resize event if it wasn't resizing.