### PR TITLE
Fix RGFW__osxKeyUp passing 1 as `pressed`.

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -13094,7 +13094,7 @@ static void RGFW__osxKeyUp(id self, SEL _cmd, id event) {
     RGFW_key value = (u8)RGFW_apiKeyToRGFW(key);
     RGFW_bool repeat = RGFW_window_isKeyDown(win, (u8)value);
 
-    RGFW_keyCallback(win, value, win->internal.mod, repeat, 1);
+    RGFW_keyCallback(win, value, win->internal.mod, repeat, 0);
 }
 
 static void RGFW__osxFlagsChanged(id self, SEL _cmd, id event) {


### PR DESCRIPTION
Right now in RGFW__osxKeyUp the callback is being called with `pressed` = 1 which should be 0 instead.