### PR TITLE
FIX: define _POSIX_C_SOURCE macro

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -358,6 +358,10 @@ int main() {
 	#endif
 #endif
 
+#ifndef _POSIX_C_SOURCE
+	#define _POSIX_C_SOURCE 199309L
+#endif
+
 #if defined(__cplusplus) && !defined(__EMSCRIPTEN__)
 	extern "C" {
 #endif
@@ -4731,9 +4735,6 @@ void RGFW_window_setDND(RGFW_window* win, RGFW_bool allow) {
 #endif
 
 #if defined(RGFW_X11) || defined(RGFW_MACOS) || defined(RGFW_WASM) || defined(RGFW_WAYLAND)
-#ifndef __USE_POSIX199309
-	#define __USE_POSIX199309
-#endif
 #include <time.h>
 struct timespec;
 #endif


### PR DESCRIPTION
It doesn't compile with `-std=c99` flag on Alpine Linux:
```console
~/cloned/RGFW$ cc -std=c99 -o test test.c -lX11 -lXrandr
In file included from test.c:2:
RGFW.h: In function 'RGFW_linux_getTimeNS':
RGFW.h:5582:5: error: implicit declaration of function 'clock_gettime' [-Wimplicit-function-declaration]
 5582 |     clock_gettime(_RGFW->clock, &ts);
      |     ^~~~~~~~~~~~~
RGFW.h: In function 'RGFW_initPlatform':
RGFW.h:5881:27: error: 'CLOCK_MONOTONIC' undeclared (first use in this function)
 5881 |         if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
      |                           ^~~~~~~~~~~~~~~
RGFW.h:5881:27: note: each undeclared identifier is reported only once for each function it appears in
```

The solution is to define `_POSIX_C_SOURCE` macro.