### PR TITLE
Thoughts on C89

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -3365,10 +3365,10 @@ void RGFW_setDualEventCallback(RGFW_eventType type, RGFW_genericFunc func, RGFW_
 }
 
 void RGFW_setAllEventCallbacks(RGFW_genericFunc func, RGFW_callbacks* callbacks) {
-	for (RGFW_eventType i = RGFW_eventNone + 1; i < RGFW_eventCount; i++) {
+	{RGFW_eventType i; for (i = RGFW_eventNone + 1; i < RGFW_eventCount; i++) {
 		if (callbacks) callbacks->arr[i] = _RGFW->callbacks[i];
 		RGFW_setEventCallback(i, func);
-	}
+	}}
 }
 
 RGFW_debugFunc RGFW_setDebugCallback(RGFW_debugFunc func) {
@@ -3843,9 +3843,9 @@ void RGFW_deinit_ptr(RGFW_info* info) {
     RGFW_setInfo(info);
 	RGFW_unloadEGL();
 
-	for (RGFW_mouseIcon i = 0; i < RGFW_mouseIconCount; i++) {
+	{RGFW_mouseIcon i; for (i = 0; i < RGFW_mouseIconCount; i++) {
 		if (_RGFW->standardMice[i]) RGFW_freeMouse(_RGFW->standardMice[i]);
-	}
+	}}
 
 	RGFW_debugCallback(RGFW_typeInfo, RGFW_infoGlobal, "global context deinitialized");
 	RGFW_deinitPlatform();
@@ -4153,10 +4153,10 @@ RGFW_event* RGFW_window_eventQueuePop(RGFW_window* win) {
 	RGFW_event* ev = RGFW_eventQueuePop();
 	if (ev == NULL) return ev;
 
-	for (i32 i = 1; i < _RGFW->eventLen && ev->common.win != win && ev->common.win != NULL; i++) {
+	{i32 i; for (i = 1; i < _RGFW->eventLen && ev->common.win != win && ev->common.win != NULL; i++) {
 		RGFW_eventQueuePush(ev);
 		ev = RGFW_eventQueuePop();
-	}
+	}}
 
 	if (ev->common.win != win && ev->common.win != NULL) {
 		return NULL;
@@ -4477,13 +4477,13 @@ void RGFW_monitors_remove(RGFW_monitorNode* node, RGFW_monitorNode* prev) {
 
 void RGFW_monitors_refresh(void) {
 	RGFW_monitorNode* prev = _RGFW->monitors.list.head;
-	for (RGFW_monitorNode* node = _RGFW->monitors.list.head; node; node = node->next) {
+	{RGFW_monitorNode* node; for (node = _RGFW->monitors.list.head; node; node = node->next) {
 		if (node->disconnected == RGFW_FALSE) continue;
 
 		RGFW_monitorCallback(_RGFW->root, &node->mon, RGFW_FALSE);
 		RGFW_monitors_remove(node, prev);
 		prev = node;
-	}
+	}}
 }
 
 RGFW_monitorMode* RGFW_monitor_getModes(RGFW_monitor* monitor, size_t* count) {
@@ -4507,7 +4507,7 @@ RGFW_bool RGFW_monitor_findClosestMode(RGFW_monitor* monitor, RGFW_monitorMode* 
 	RGFW_monitorMode* chosen = NULL;
 
 	u32 topScore = 1;
-	for (size_t i = 0; i < count; i++) {
+	{size_t i; for (i = 0; i < count; i++) {
 		RGFW_monitorMode* mode2 = &modes[i];
 
 		u32 score = 0;
@@ -4519,7 +4519,7 @@ RGFW_bool RGFW_monitor_findClosestMode(RGFW_monitor* monitor, RGFW_monitorMode* 
 			topScore = score;
 			chosen = mode2;
 		}
-	}
+	}}
 
 	if (chosen && closest) *closest = *chosen;
 
@@ -4755,11 +4755,11 @@ void RGFW_moveToMacOSResourceDir(void) { }
 
 RGFWDEF RGFW_bool RGFW_isLatin(const char *string, size_t length);
 RGFW_bool RGFW_isLatin(const char *string, size_t length) {
-	for (size_t i = 0; i < length; i++) {
+    {size_t i; for (i = 0; i < length; i++) {
         if ((u8)string[i] >= 0x80) {
             return RGFW_TRUE;
         }
-    }
+    }}
     return RGFW_FALSE;
 }
 
@@ -6097,12 +6097,12 @@ void RGFW_x11_imInitCallback(Display* display, XPointer clientData, XPointer cal
     if (XGetIMValues(_RGFW->im, XNQueryInputStyle, &styles, NULL) != NULL) {
         found = RGFW_FALSE;
 	} else {
-		for (unsigned int i = 0;  i < styles->count_styles;  i++) {
+		{unsigned int i; for (i = 0; i < styles->count_styles;  i++) {
 			if (styles->supported_styles[i] == (XIMPreeditNothing | XIMStatusNothing)) {
 				found = RGFW_TRUE;
 				break;
 			}
-		}
+		}}
 
 	    XFree(styles);
 	}
@@ -6674,9 +6674,9 @@ void RGFW_XHandleEvent(void) {
 
 				if (status == XLookupChars || status == XLookupBoth) {
 					chars[count] = '\0';
-					for (size_t index = 0; index < count;
+					{size_t index; for (index = 0; index < count;
 						RGFW_keyCharCallback(win, RGFW_decodeUTF8(&chars[index], &index))
-					);
+					);}
 				}
 
 				if (chars != buffer)
@@ -7747,10 +7747,10 @@ void RGFW_XGetSystemContentDPI(float* dpi) {
 RGFWDEF XRRModeInfo* RGFW_XGetMode(XRRCrtcInfo* ci, XRRScreenResources* res, RRMode mode, RGFW_monitorMode* foundMode);
 XRRModeInfo* RGFW_XGetMode(XRRCrtcInfo* ci, XRRScreenResources* res, RRMode mode, RGFW_monitorMode* foundMode) {
 	XRRModeInfo* mi = None;
-	for (i32 j = 0; j < res->nmode; j++) {
+	{i32 j; for (j = 0; j < res->nmode; j++) {
 		if (res->modes[j].id ==  mode)
 			mi = &res->modes[j];
-	}
+	}}
 
 	if (mi == None) return NULL;
 
@@ -7809,11 +7809,11 @@ void RGFW_FUNC(RGFW_pollMonitors) (void) {
 
 	RROutput primary = XRRGetOutputPrimary(_RGFW->display, root);
 
-	for (RGFW_monitorNode* node = _RGFW->monitors.list.head; node; node = node->next) {
+	{RGFW_monitorNode* node; for (node = _RGFW->monitors.list.head; node; node = node->next) {
 		node->disconnected = RGFW_TRUE;
-	}
+	}}
 
-	for (i32 i = 0; i < res->noutput; i++) {
+	{i32 i; for (i = 0; i < res->noutput; i++) {
 		RGFW_monitorNode* node = NULL;
 		for (node = _RGFW->monitors.list.head; node; node = node->next) {
 			if (node->rrOutput == res->outputs[i]) {
@@ -7891,7 +7891,7 @@ void RGFW_FUNC(RGFW_pollMonitors) (void) {
 		info = NULL;
 
 		RGFW_monitorCallback(_RGFW->root, &node->mon, RGFW_TRUE);
-	}
+	}}
 
 	XRRFreeScreenResources(res);
 
@@ -8090,10 +8090,10 @@ RGFW_monitor* RGFW_FUNC(RGFW_window_getMonitor) (RGFW_window* win) {
 		return NULL;
 	}
 
-	for (RGFW_monitorNode* node = _RGFW->monitors.list.head; node; node = node->next) {
+	{RGFW_monitorNode* node; for (node = _RGFW->monitors.list.head; node; node = node->next) {
 		if ((attrs.x < node->mon.x + node->mon.mode.w) && (attrs.x + attrs.width > node->mon.x) && (attrs.y < node->mon.y + node->mon.mode.h) && (attrs.y + attrs.height > node->mon.y))
 			return &node->mon;
-	}
+	}}
 
 
 	return &_RGFW->monitors.list.head->mon;
@@ -10106,22 +10106,22 @@ RGFW_ssize_t RGFW_FUNC(RGFW_readClipboardPtr) (char* str, size_t strCapacity) {
 
 void RGFW_FUNC(RGFW_writeClipboard) (const char* text, u32 textLen) {
 
-	// compositor does not support wl_data_device_manager
-	// clients cannot read rgfw's clipboard
+	/* compositor does not support wl_data_device_manager */
+	/* clients cannot read rgfw's clipboard */
 	if (_RGFW->data_device_manager == NULL) return;
 	// clear the clipboard
 	if (_RGFW->clipboard)
 		RGFW_FREE(_RGFW->clipboard);
 
-	// set the contents
+	/* set the contents */
 	_RGFW->clipboard = (char*)RGFW_ALLOC(textLen);
 	RGFW_ASSERT(_RGFW->clipboard != NULL);
 	RGFW_STRNCPY(_RGFW->clipboard, text, textLen - 1);
 	_RGFW->clipboard[textLen - 1] = '\0';
 	_RGFW->clipboard_len = textLen;
 
-	// means we already wrote to the clipboard
-	// so destroy it to create a new one
+	/* means we already wrote to the clipboard
+	 * so destroy it to create a new one */
 	RGFW_window* win = _RGFW->kbOwner;
 
 	if (win->src.data_source != NULL) {
@@ -10129,18 +10129,18 @@ void RGFW_FUNC(RGFW_writeClipboard) (const char* text, u32 textLen) {
 		win->src.data_source = NULL;
 	}
 
-	// advertise to other clients that we offer text
+	/* advertise to other clients that we offer text */
 	win->src.data_source = wl_data_device_manager_create_data_source(_RGFW->data_device_manager);
 
-	// basic error checking
+	/* basic error checking */
 	if (win->src.data_source == NULL) {
 		RGFW_debugCallback(RGFW_typeError, RGFW_errClipboard, "Could not create clipboard data source");
 		return;
 	}
 	wl_data_source_offer(win->src.data_source , "text/plain;charset=utf-8");
 
-	// needed RGFW_doNothing because wayland will call the functions
-	// if not set they are random data that lead to a crash
+	/* needed RGFW_doNothing because wayland will call the functions
+	 * if not set they are random data that lead to a crash */
 	static const struct wl_data_source_listener data_source_listener = {
 		.target = (void (*)(void *, struct wl_data_source *, const char *))&RGFW_doNothing,
 		.action = (void (*)(void *, struct wl_data_source *, u32))&RGFW_doNothing,


### PR DESCRIPTION
It's not a suggestion in a sense, just some ideas to make RGFW compatible (not really) with C89.
```console
~/cloned/RGFW$ gcc -std=c89 -Wall -Wextra -o test test.c -lX11 -lXrandr
~/cloned/RGFW$ clang -std=c89 -Wall -Wextra -o test test.c -lX11 -lXrandr
In file included from test.c:3:
./RGFW.h:6258:5: warning: static function 'RGFW_c89_snprintf' is used in an inline function with
      external linkage [-Wstatic-in-inline]
 6258 |     RGFW_SNPRINTF(buf, sizeof(buf),  "[X Error] %s\n  Error code: %d\n  Request code: %d\...
      |     ^
./RGFW.h:240:29: note: expanded from macro 'RGFW_SNPRINTF'
  240 |         #define RGFW_SNPRINTF RGFW_c89_snprintf
      |                               ^
./RGFW.h:6252:1: note: use 'static' to give inline function 'RGFW_XErrorHandler' internal linkage
 6252 | RGFWDEF int RGFW_XErrorHandler(Display* display, XErrorEvent* ev);
      | ^
      | static 
./RGFW.h:355:19: note: expanded from macro 'RGFWDEF'
  355 |                 #define RGFWDEF __inline
      |                                 ^
./RGFW.h:231:20: note: 'RGFW_c89_snprintf' declared here
  231 |         static int RGFW_c89_snprintf(char *dst, size_t size, const char *format, ...) {
      |                    ^
1 warning generated.
~/cloned/RGFW$ # it compiled successfully, even though it's not fully c89-compliant
```

And yes, I do know about `-pedantic` and that `mixing declarations and code is a C99 extension`, but still. Small incremental steps towards C89.