### PR TITLE
Added RGFW_USE_VOLK to use Volk instead of vulkan header

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -2610,7 +2610,11 @@ RGFWDEF RGFW_bool RGFW_extensionSupportedPlatform_EGL(const char* extension, siz
 #endif
 
 #ifdef RGFW_VULKAN
+#ifndef RGFW_USE_VOLK
 #include <vulkan/vulkan.h>
+#else
+#include <Volk/volk.h>
+#endif
 
 /* if you don't want to use the above macros */
 


### PR DESCRIPTION
Just in case the user want to include volk instead of the vulkan header. I did this in my personal engine because I only use Volk and it fixed linking errors