### PR TITLE
Fix memory leak on wayland

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -9334,6 +9334,9 @@ static void RGFW_wl_data_device_selection(void *data, struct wl_data_device *wl_
 
 	ssize_t n = read(pfds[0], buf, sizeof(buf));
 
+	if (_RGFW->clipboard) {
+		RGFW_FREE(_RGFW->clipboard);
+	}
 	_RGFW->clipboard = (char*)RGFW_ALLOC((size_t)n);
 	RGFW_ASSERT(_RGFW->clipboard != NULL);
 	RGFW_STRNCPY(_RGFW->clipboard, buf, (size_t)n);


### PR DESCRIPTION
I fixed a memory leak that occurs on Wayland when the clipboard isn't empty and the window focus changes at least once.

Steps to reproduce the leak:
1. Compile examples with `WAYLAND=1 make`.
2. Copy some text to make sure clipboard isn't empty.
3. Run an example with valgrind (or ASan): `valgrind --leak-check=full ./examples/surface/surface`.
4. Change focus from the example window to another window.
5. Close the example window.