### PR TITLE
X11 initialization checks

### DIFF
--- a/RGFW.h
+++ b/RGFW.h
@@ -3937,6 +3937,7 @@ i32 RGFW_init_ptr(RGFW_info* info) {
 	_RGFW->monitors.list.head = NULL;
     RGFW_initKeycodes();
     i32 out = RGFW_initPlatform();
+    if (out != 0) { RGFW_deinit(); return out; }
 
 	for (size_t i = 0; i < RGFW_mouseIconCount; i++) {
         _RGFW->standardMice[i] = RGFW_createMouseStandard((RGFW_mouseIcon)i);
@@ -8639,6 +8640,22 @@ i32 RGFW_initPlatform_X11(void) {
 
 void RGFW_deinitPlatform_X11(void) {
     #define RGFW_FREE_LIBRARY(x) if (x != NULL) dlclose(x); x = NULL;
+	if (_RGFW->display == NULL) {
+        #if !defined(RGFW_NO_X11_CURSOR_PRELOAD) && !defined(RGFW_NO_X11_CURSOR)
+            RGFW_FREE_LIBRARY(X11Cursorhandle);
+        #endif
+        #if !defined(RGFW_NO_X11_XI_PRELOAD)
+            RGFW_FREE_LIBRARY(X11Xihandle);
+        #endif
+        #ifdef RGFW_USE_XDL
+            XDL_close();
+        #endif
+        #if !defined(RGFW_NO_X11_EXT_PRELOAD)
+            RGFW_FREE_LIBRARY(X11XEXThandle);
+        #endif
+        return;
+    }
+
 	/* to save the clipboard on the x server after the window is closed */
 	RGFW_LOAD_ATOM(CLIPBOARD_MANAGER);  RGFW_LOAD_ATOM(CLIPBOARD);
 	RGFW_LOAD_ATOM(SAVE_TARGETS);

--- a/RGFW.h
+++ b/RGFW.h
@@ -3990,7 +3990,7 @@ RGFW_window* RGFW_createWindowPtr(const char* name, i32 x, i32 y, i32 w, i32 h, 
 
 	RGFW_MEMZERO(win, sizeof(RGFW_window));
 
-	if (_RGFW == NULL) RGFW_init();
+	if (_RGFW == NULL) if (RGFW_init() != 0) return NULL;
 	_RGFW->windowCount++;
 
 	/* rect based the requested flags */

--- a/RGFW.h
+++ b/RGFW.h
@@ -8577,6 +8577,11 @@ i32 RGFW_initPlatform_X11(void) {
 
     XInitThreads(); /*!< init X11 threading */
     _RGFW->display = XOpenDisplay(0);
+    if (_RGFW->display == NULL) {
+        RGFW_debugCallback(RGFW_typeError, RGFW_errX11,
+            "Failed to open X11 display. (Is $DISPLAY set?)");
+        return -1;
+    }
 	_RGFW->context = XUniqueContext();
 
 	XSetWindowAttributes wa;


### PR DESCRIPTION
In some circumstances, like when running Wayland-based desktop manager where X11 runs through XWayland, it's possible that X11's `DISPLAY` environment variable is not set, and it would cause a crash in `RGFW_initPlatform_X11`.

In addition, because of lazy initialization, we need an early-out (and cleanup) during `RGFW_init_ptr` as it may be called by other functions like `RGFW_getGlobalHints_OpenGL`.
