### PR TITLE
review fullscreen support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ endif
 
 RGFW$(OBJ_FILE): RGFW.h $(WAYLAND_SOURCE)
 ifeq ($(detected_OS), windows)
-	copy RGFW.h RGFW.c
+	copy .\RGFW.h RGFW.c
 else
 	cp RGFW.h RGFW.c
 endif

--- a/Makefile
+++ b/Makefile
@@ -376,17 +376,24 @@ endif
 ifeq ($(detected_OS), windows)
 		./examples/dx11/dx11.exe
 endif
-	$(MAKE) clean
+	make clean
 
 
 RGFW$(OBJ_FILE): RGFW.h $(WAYLAND_SOURCE)
-	#$(CC) -x c $(CUSTOM_CFLAGS) -c RGFW.h -D RGFW_IMPLEMENTATION -fPIC -D RGFW_EXPORT
+ifeq ($(detected_OS), windows)
+	copy RGFW.h RGFW.c
+else
 	cp RGFW.h RGFW.c
+endif
 	$(CC) $(CUSTOM_CFLAGS) $(DEFINES) -c RGFW.c -D RGFW_IMPLEMENTATION -fPIC -D RGFW_EXPORT
+ifeq ($(detected_OS), windows)
+	del RGFW.c
+else
 	rm RGFW.c
+endif
 
 libRGFW$(LIB_EXT): RGFW.h RGFW$(OBJ_FILE)
-	$(MAKE) RGFW$(OBJ_FILE)
+	make RGFW$(OBJ_FILE)
 ifeq ($(CC), cl)
 	link /DLL /OUT:libRGFW.dll RGFW.obj
 else
@@ -394,13 +401,16 @@ else
 endif
 
 libRGFW.a: RGFW.h RGFW$(OBJ_FILE)
-	$(MAKE) RGFW$(OBJ_FILE)
+	make RGFW$(OBJ_FILE)
+ifeq ($(CC), cl)
+else
 	$(AR) rcs libRGFW.a RGFW$(OBJ_FILE)
+endif
 
 ifeq ($(WAYLAND),1)
 
 $(WAYLAND_SOURCE): %.c:
-	$(MAKE) -f wayland.mk
+	make -f wayland.mk
 
 endif
 
@@ -409,7 +419,7 @@ clean:
 	rm -f *.o *.obj *.dll .dylib *.a *.so $(EXAMPLE_OUTPUTS) $(EXAMPLE_OUTPUTS_CUSTOM) $(TEST_OUTPUTS)  .$(OS_DIR)examples$(OS_DIR)*$(OS_DIR)*.exe .$(OS_DIR)examples$(OS_DIR)*$(OS_DIR)*.js .$(OS_DIR)examples$(OS_DIR)*$(OS_DIR)*.wasm .$(OS_DIR)examples$(OS_DIR)vk10$(OS_DIR)shaders$(OS_DIR)*.h
 
 ifeq ($(WAYLAND),1)
-	$(MAKE) -f wayland.mk clean
+	make -f wayland.mk clean
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -381,6 +381,7 @@ endif
 
 RGFW$(OBJ_FILE): RGFW.h $(WAYLAND_SOURCE)
 ifeq ($(detected_OS), windows)
+	dir
 	copy .\RGFW.h RGFW.c
 else
 	cp RGFW.h RGFW.c

--- a/Makefile
+++ b/Makefile
@@ -381,13 +381,13 @@ endif
 
 RGFW$(OBJ_FILE): RGFW.h $(WAYLAND_SOURCE)
 ifeq ($(detected_OS), windows)
-	cp RGFW.h RGFW.c
+	cmd /c copy RGFW.h RGFW.c
 else
 	cp RGFW.h RGFW.c
 endif
 	$(CC) $(CUSTOM_CFLAGS) $(DEFINES) -c RGFW.c -D RGFW_IMPLEMENTATION -fPIC -D RGFW_EXPORT
 ifeq ($(detected_OS), windows)
-	del RGFW.c
+	cmd /c del RGFW.c
 else
 	rm RGFW.c
 endif

--- a/Makefile
+++ b/Makefile
@@ -381,8 +381,7 @@ endif
 
 RGFW$(OBJ_FILE): RGFW.h $(WAYLAND_SOURCE)
 ifeq ($(detected_OS), windows)
-	dir
-	copy RGFW.h RGFW.c
+	cp RGFW.h RGFW.c
 else
 	cp RGFW.h RGFW.c
 endif

--- a/Makefile
+++ b/Makefile
@@ -382,7 +382,7 @@ endif
 RGFW$(OBJ_FILE): RGFW.h $(WAYLAND_SOURCE)
 ifeq ($(detected_OS), windows)
 	dir
-	copy .\RGFW.h RGFW.c
+	copy RGFW.h RGFW.c
 else
 	cp RGFW.h RGFW.c
 endif

--- a/RGFW.h
+++ b/RGFW.h
@@ -7035,6 +7035,7 @@ RGFW_bool RGFW_XCreateWindow (XVisualInfo visual, const char* name, RGFW_windowF
 	XSetClassHint(_RGFW->display, win->src.window, &hint);
 
 	XWMHints hints;
+	RGFW_MEMZERO(&hints, sizeof(hints));
 	hints.flags = StateHint;
 	hints.initial_state = NormalState;
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -5193,7 +5193,7 @@ void RGFW_window_setFullscreen(RGFW_window* win, RGFW_fullscreenMode fullscreen)
 	RGFW_ASSERT(win != NULL);
 	if ((fullscreen == RGFW_fullscreenExclusive && (win->internal.flags & RGFW_windowFullscreenExclusive)) || 
 		(fullscreen == RGFW_fullscreenBorderless && RGFW_BOOL(win->internal.flags & RGFW_windowFullscreenBorderless)) ||
-		fullscreen == 0 && RGFW_window_isFullscreen(win) == RGFW_FALSE) {
+		(fullscreen == 0 && RGFW_window_isFullscreen(win) == RGFW_FALSE)) {
 			return;
 	}
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -924,13 +924,24 @@ typedef struct RGFW_callbacks {
 	RGFW_genericFunc arr[RGFW_eventCount]; /*!< an array of all the callbacks */
 } RGFW_callbacks;
 
+typedef RGFW_ENUM(u8, RGFW_fullscreenMode) {
+	RGFW_fullscreenNone,
+	/*!< borderless/windowed fullscreen | the window changes it's size to match the monitor's current mode 
+										   the window is not hidden and maintains it's size when it is unfocused */
+	RGFW_fullscreenBorderless, /*!< borderless/windowed fullscreen */
+	/*!< exclusive fullscreen | the monitor's mode tries to change to match the window's size. 
+								The original mode is toggled when the window goes in and out of focus and 
+								the window is hidden when it is not in focus */
+	RGFW_fullscreenExclusive, /*!< exclusive fullscreen */
+};
+
 /*! @brief optional bitwise arguments for making a windows, these can be OR'd together */
 typedef RGFW_ENUM(u32, RGFW_windowFlags) {
 	RGFW_windowNoBorder = RGFW_BIT(0), /*!< the window doesn't have a border / frame / decor */
 	RGFW_windowNoResize = RGFW_BIT(1), /*!< the window cannot be resized by the user */
 	RGFW_windowAllowDND = RGFW_BIT(2), /*!< the window supports drag and drop */
 	RGFW_windowHideMouse = RGFW_BIT(3), /*! the window should hide the mouse (can be toggled later on using `RGFW_window_showMouse`) */
-	RGFW_windowFullscreen = RGFW_BIT(4), /*!< the window is fullscreen by default */
+	RGFW_windowFullscreenExclusive = RGFW_BIT(4), /*!< the window is exclusive fullscreen by default */
 	RGFW_windowTranslucent = RGFW_BIT(5), /*!< the window is translucent (only properly works on X11 and MacOS, although it's meant for for windows) */
 	RGFW_windowTransparent = RGFW_windowTranslucent,  /*!< the window is translucent (only properly works on X11 and MacOS, although it's meant for for windows) */
 	RGFW_windowCenter = RGFW_BIT(6), /*! center the window on the screen */
@@ -946,7 +957,7 @@ typedef RGFW_ENUM(u32, RGFW_windowFlags) {
 	RGFW_windowCaptureMouse = RGFW_BIT(16), /*!< capture the mouse mouse mouse on window creation */
 	RGFW_windowOpenGL = RGFW_BIT(17), /*!< create an OpenGL context (you can also do this manually with RGFW_window_createContext_OpenGL) */
 	RGFW_windowEGL = RGFW_BIT(18), /*!< create an EGL context (you can also do this manually with RGFW_window_createContext_EGL) */
-	RGFW_windowedFullscreen = RGFW_windowNoBorder | RGFW_windowMaximize,
+	RGFW_windowFullscreenBorderless = RGFW_BIT(19), /*!< the window is borderless fullscreen by default */ 
 	RGFW_windowCaptureRawMouse = RGFW_windowCaptureMouse | RGFW_windowRawMouse
 };
 
@@ -2069,7 +2080,7 @@ RGFWDEF void RGFW_window_maximize(RGFW_window* win);
  * @param win a pointer to the target window
  * @param fullscreen RGFW_TRUE to enable fullscreen, RGFW_FALSE to disable
 */
-RGFWDEF void RGFW_window_setFullscreen(RGFW_window* win, RGFW_bool fullscreen);
+RGFWDEF void RGFW_window_setFullscreen(RGFW_window* win, RGFW_fullscreenMode mode);
 
 /**!
  * @brief centers the window on the screen
@@ -3094,7 +3105,9 @@ typedef struct RGFW_windowInternal {
 	RGFW_eventFlag enabledEvents;
 	u32 flags; /*!< windows flags (for RGFW to check and modify) */
 	i32 oldX, oldY, oldW, oldH;
-	RGFW_monitorMode oldMode;
+	RGFW_bool oldBorder;
+	RGFW_monitor* monitor;
+	RGFW_monitorMode oldMode, newMode;
 	RGFW_mouse* mouse;
 } RGFW_windowInternal;
 
@@ -3375,6 +3388,7 @@ RGFWDEF void RGFW_window_minimizePlatform(RGFW_window* win);
 RGFWDEF void RGFW_window_movePlatform(RGFW_window* win, i32 x, i32 y);
 RGFWDEF void RGFW_window_resizePlatform(RGFW_window* win, i32 w, i32 h);
 RGFWDEF void RGFW_window_maximizePlatform(RGFW_window* win);
+RGFWDEF void RGFW_window_setFullscreenPlatform(RGFW_window* win, RGFW_bool fullscreen);
 RGFWDEF void RGFW_window_setFlagsInternal(RGFW_window* win, RGFW_windowFlags flags, RGFW_windowFlags cmpFlags);
 
 RGFWDEF void RGFW_initKeycodes(void);
@@ -3723,13 +3737,17 @@ void RGFW_windowFocusCallback(RGFW_window* win, RGFW_bool inFocus) {
 	event.focus.state = inFocus;
 
 	if (inFocus == RGFW_TRUE) {
-		if ((win->internal.flags & RGFW_windowFullscreen))
+		if ((win->internal.flags & RGFW_windowFullscreenExclusive) && win->internal.monitor) {
 			RGFW_window_raise(win);
+			RGFW_monitor_setMode(win->internal.monitor, &win->internal.newMode);
+		}
 
 		event.type = RGFW_windowFocusIn;
 	} else if (inFocus == RGFW_FALSE) {
-		if ((win->internal.flags & RGFW_windowFullscreen))
+		if ((win->internal.flags & RGFW_windowFullscreenExclusive) && win->internal.monitor) {
 			RGFW_window_minimize(win);
+			RGFW_monitor_setMode(win->internal.monitor, &win->internal.oldMode);
+		}
 
 		size_t key;
 		for (key = 0; key < RGFW_keyLast; key++) {
@@ -4236,7 +4254,7 @@ RGFW_window* RGFW_createWindowPtr(const char* name, i32 x, i32 y, i32 w, i32 h, 
 	if (!(flags & RGFW_windowHide)) {
 		flags |= RGFW_windowHide;
 		RGFW_window_show(win);
-	} else if ((flags & RGFW_windowMaximize) || (flags & RGFW_windowFullscreen)) {
+	} else if ((flags & RGFW_windowMaximize) || (flags & RGFW_windowFullscreenExclusive) || (flags & RGFW_windowFullscreenBorderless)) {
 		RGFW_window_hide(win);
 	}
 
@@ -4247,6 +4265,10 @@ RGFW_window* RGFW_createWindowPtr(const char* name, i32 x, i32 y, i32 w, i32 h, 
 
 void RGFW_window_closePtr(RGFW_window* win) {
 	RGFW_ASSERT(win != NULL);
+
+	if ((win->internal.flags & RGFW_windowFullscreenExclusive) && win->internal.monitor) {
+		RGFW_monitor_setMode(win->internal.monitor, &win->internal.oldMode);
+	}
 
 	if (win->internal.captureMouse) {
 		RGFW_window_captureMouse(win, RGFW_FALSE);
@@ -4471,8 +4493,10 @@ void RGFW_window_setFlagsInternal(RGFW_window* win, RGFW_windowFlags flags, RGFW
 	else if (cmpFlags & RGFW_windowMinimize)    RGFW_window_restore(win);
 	if (flags & RGFW_windowCenter)              RGFW_window_center(win);
 	if (flags & RGFW_windowCenterCursor)        RGFW_window_moveMouse(win, win->x + (win->w / 2), win->y + (win->h / 2));
-	if (flags & RGFW_windowFullscreen)          RGFW_window_setFullscreen(win, RGFW_TRUE);
-	else if (cmpFlags & RGFW_windowFullscreen)  RGFW_window_setFullscreen(win, 0);
+	if (flags & RGFW_windowFullscreenExclusive)          RGFW_window_setFullscreen(win, RGFW_fullscreenExclusive);
+	else if (cmpFlags & RGFW_windowFullscreenExclusive)  RGFW_window_setFullscreen(win, 0);
+	if (flags & RGFW_windowFullscreenBorderless) RGFW_window_setFullscreen(win, RGFW_fullscreenBorderless);
+	else if (cmpFlags & RGFW_fullscreenBorderless)  RGFW_window_setFullscreen(win, 0);
 	if (flags & RGFW_windowHideMouse)           RGFW_window_showMouse(win, 0);
 	else if (cmpFlags & RGFW_windowHideMouse)   RGFW_window_showMouse(win, 1);
 	if (flags & RGFW_windowHide)                RGFW_window_hide(win);
@@ -5043,7 +5067,7 @@ RGFW_bool RGFW_window_borderless(RGFW_window* win) {
 	return (RGFW_bool)RGFW_BOOL(win->internal.flags & RGFW_windowNoBorder);
 }
 
-RGFW_bool RGFW_window_isFullscreen(RGFW_window* win){ return RGFW_BOOL(win->internal.flags & RGFW_windowFullscreen); }
+RGFW_bool RGFW_window_isFullscreen(RGFW_window* win){ return RGFW_BOOL(win->internal.flags & RGFW_windowFullscreenExclusive) || RGFW_BOOL(win->internal.flags & RGFW_windowFullscreenBorderless); }
 RGFW_bool RGFW_window_allowsDND(RGFW_window* win) { return RGFW_BOOL(win->internal.flags & RGFW_windowAllowDND); }
 
 RGFW_bool RGFW_window_setMouseDefault(RGFW_window* win) {
@@ -5116,12 +5140,14 @@ u32 RGFW_decodeUTF8(const char* string, size_t* starting_index) {
 }
 
 void RGFW_window_show(RGFW_window* win) {
+	RGFW_ASSERT(win != NULL);
 	if (win->internal.flags & RGFW_windowFocusOnShow) RGFW_window_focus(win);
 	RGFW_window_showPlatform(win);
-	if ((win->internal.flags & RGFW_windowMaximize)) { RGFW_window_maximize(win); }
+	if ((win->internal.flags & RGFW_windowMaximize)) RGFW_window_maximize(win);
 }
 
 void RGFW_window_restore(RGFW_window* win) {
+	RGFW_ASSERT(win != NULL);
 	RGFW_window_restorePlatform(win);
 	win->internal.flags &= ~(u32)RGFW_windowMaximize;
 	RGFW_window_show(win);
@@ -5130,6 +5156,7 @@ void RGFW_window_restore(RGFW_window* win) {
 }
 
 void RGFW_window_minimize(RGFW_window* win) {
+	RGFW_ASSERT(win != NULL);
 	RGFW_window_minimizePlatform(win);
 	win->internal.flags &= ~(u32)RGFW_windowMaximize;
 }
@@ -5147,6 +5174,7 @@ void RGFW_window_maximize(RGFW_window* win) {
 }
 
 void RGFW_window_move(RGFW_window* win, i32 x, i32 y) {
+	RGFW_ASSERT(win != NULL);
 	win->x = x;
 	win->y = y;
 	RGFW_window_movePlatform(win, x, y);
@@ -5154,10 +5182,61 @@ void RGFW_window_move(RGFW_window* win, i32 x, i32 y) {
 }
 
 void RGFW_window_resize(RGFW_window* win, i32 w, i32 h) {
+	RGFW_ASSERT(win != NULL);
 	win->w = w;
 	win->h = h;
 	RGFW_window_resizePlatform(win, w, h);
 	win->internal.flags &= ~(u32)RGFW_windowMaximize;
+}
+
+void RGFW_window_setFullscreen(RGFW_window* win, RGFW_fullscreenMode fullscreen) {
+	printf("hello\n");
+	RGFW_ASSERT(win != NULL);
+	if (fullscreen) {
+		win->internal.oldX = win->x;
+		win->internal.oldY = win->y;
+		win->internal.oldW = win->w;
+		win->internal.oldH = win->h;
+		win->internal.oldBorder = RGFW_window_borderless(win);
+		RGFW_window_setBorder(win, 0);
+		RGFW_window_move(win, 0, 0);
+
+		RGFW_monitor* mon  = RGFW_window_getMonitor(win);
+
+		if (fullscreen == RGFW_fullscreenExclusive) {
+			win->internal.oldMode = mon->mode;
+			RGFW_monitor_scaleToWindow(mon, win);
+			win->internal.monitor = mon;
+			win->internal.newMode = mon->mode;
+			win->internal.flags |= RGFW_windowFullscreenExclusive;
+		} else {
+			win->internal.flags |= RGFW_windowFullscreenBorderless;
+			win->internal.monitor = NULL;
+		}
+
+		RGFW_window_resize(win, mon->mode.w, mon->mode.h);
+	}
+
+	RGFW_window_setFullscreenPlatform(win, (fullscreen > 0) ? RGFW_TRUE : RGFW_FALSE);
+
+	if (fullscreen == 0) {
+		if (win->internal.monitor != NULL) {
+			RGFW_monitor_setMode(win->internal.monitor, &win->internal.oldMode);
+		}
+
+		RGFW_window_setBorder(win, win->internal.oldBorder);
+
+		RGFW_window_move(win, win->internal.oldX, win->internal.oldY);
+		RGFW_window_resize(win, win->internal.oldW, win->internal.oldH);
+
+		win->internal.flags &= ~(u32)RGFW_windowFullscreenExclusive;
+		win->internal.flags &= ~(u32)RGFW_windowFullscreenBorderless;
+		win->x  = win->internal.oldX;
+		win->y = win->internal.oldY;
+		win->w = win->internal.oldW;
+		win->h = win->internal.oldH;
+		return;
+	}
 }
 
 /*
@@ -7780,18 +7859,7 @@ void RGFW_window_setXAtom(RGFW_window* win, Atom netAtom, RGFW_bool fullscreen) 
 	XSendEvent(_RGFW->display, DefaultRootWindow(_RGFW->display), False, SubstructureNotifyMask | SubstructureRedirectMask, &xev);
 }
 
-void RGFW_FUNC(RGFW_window_setFullscreen)(RGFW_window* win, RGFW_bool fullscreen) {
-	RGFW_ASSERT(win != NULL);
-
-	if (fullscreen) {
-		win->internal.flags |= RGFW_windowFullscreen;
-		win->internal.oldX = win->x;
-		win->internal.oldY = win->y;
-		win->internal.oldW = win->w;
-		win->internal.oldH = win->h;
-	}
-	else win->internal.flags &= ~(u32)RGFW_windowFullscreen;
-
+void RGFW_FUNC(RGFW_window_setFullscreenPlatform)(RGFW_window* win, RGFW_bool fullscreen) {
 	XRaiseWindow(_RGFW->display, win->src.window);
 
 	RGFW_window_setXAtom(win, _RGFW->_NET_WM_STATE_FULLSCREEN, fullscreen);
@@ -10440,21 +10508,12 @@ void RGFW_FUNC(RGFW_window_raise)(RGFW_window* win) {
 	RGFW_ASSERT(win);
 }
 
-void RGFW_FUNC(RGFW_window_setFullscreen)(RGFW_window* win, RGFW_bool fullscreen) {
-	RGFW_ASSERT(win != NULL);
+void RGFW_FUNC(RGFW_window_setFullscreenPlatform)(RGFW_window* win, RGFW_bool fullscreen) {
     if (fullscreen) {
-
-		win->internal.flags |= RGFW_windowFullscreen;
-		win->internal.oldX = win->x;
-		win->internal.oldY = win->y;
-		win->internal.oldW = win->w;
-		win->internal.oldH = win->h;
 		xdg_toplevel_set_fullscreen(win->src.xdg_toplevel, NULL); /* let the compositor decide */
 	} else {
-		win->internal.flags &= ~(u32)RGFW_windowFullscreen;
 		xdg_toplevel_unset_fullscreen(win->src.xdg_toplevel);
 	}
-
 }
 
 void RGFW_FUNC(RGFW_window_setFloating) (RGFW_window* win, RGFW_bool floating) {
@@ -10922,7 +10981,7 @@ DWORD RGFW_winapi_window_getStyle(RGFW_window* win, RGFW_windowFlags flags) {
 	RGFW_UNUSED(win);
     DWORD style = WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
 
-    if ((flags & RGFW_windowFullscreen)) {
+    if ((flags & RGFW_windowFullscreenExclusive)) {
         style |= WS_POPUP;
     } else {
         style |= WS_SYSMENU | WS_MINIMIZEBOX;
@@ -10943,7 +11002,7 @@ DWORD RGFW_winapi_window_getStyle(RGFW_window* win, RGFW_windowFlags flags) {
 RGFWDEF DWORD RGFW_winapi_window_getExStyle(RGFW_window* win, RGFW_windowFlags flags);
 DWORD RGFW_winapi_window_getExStyle(RGFW_window* win, RGFW_windowFlags flags) {
     DWORD style = WS_EX_APPWINDOW;
-    if (flags & RGFW_windowFullscreen || (flags & RGFW_windowFloating || RGFW_window_isFloating(win))) {
+    if (flags & RGFW_windowFullscreenExclusive || (flags & RGFW_windowFloating || RGFW_window_isFloating(win))) {
         style |= WS_EX_TOPMOST;
 	}
 
@@ -11864,48 +11923,7 @@ void RGFW_window_raise(RGFW_window* win) {
 	SetWindowPos(win->src.window, HWND_TOP, win->x, win->y, win->w, win->h, SWP_NOSIZE | SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
 }
 
-void RGFW_window_setFullscreen(RGFW_window* win, RGFW_bool fullscreen) {
-	RGFW_ASSERT(win != NULL);
-
-	RGFW_monitor* mon  = RGFW_window_getMonitor(win);
-
-	if (fullscreen == RGFW_FALSE) {
-		RGFW_monitor_setMode(mon, &win->internal.oldMode);
-
-		RGFW_window_setBorder(win, 1);
-
-		RECT rect = { 0, 0, win->internal.oldW, win->internal.oldH};
-		DWORD style = RGFW_winapi_window_getStyle(win, win->internal.flags);
-		DWORD exStyle = RGFW_winapi_window_getExStyle(win, win->internal.flags);
-		AdjustWindowRectEx(&rect, style, FALSE, exStyle);
-		SetWindowPos(win->src.window, HWND_TOP, win->internal.oldX, win->internal.oldY, rect.right - rect.left, rect.bottom - rect.top, SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER);
-
-		win->internal.flags &= ~(u32)RGFW_windowFullscreen;
-		win->x  = win->internal.oldX;
-		win->y = win->internal.oldY;
-		win->w = win->internal.oldW;
-		win->h = win->internal.oldH;
-		return;
-	}
-
-	win->internal.oldX = win->x;
-	win->internal.oldY = win->y;
-	win->internal.oldW = win->w;
-	win->internal.oldH = win->h;
-	win->internal.oldMode = mon->mode;
-	win->internal.flags |= RGFW_windowFullscreen;
-
-	RGFW_window_setBorder(win, 0);
-
-    SetWindowPos(win->src.window, HWND_TOPMOST, (i32)mon->x, (i32)mon->y, 0, 0, SWP_NOOWNERZORDER | SWP_FRAMECHANGED | SWP_SHOWWINDOW | SWP_NOSIZE);
-	win->x = mon->x;
-	win->y = mon->y;
-
-	RGFW_monitor_scaleToWindow(mon, win);
-    SetWindowPos(win->src.window, HWND_TOPMOST, 0, 0, (i32)mon->mode.w, (i32)mon->mode.h, SWP_NOOWNERZORDER | SWP_FRAMECHANGED | SWP_SHOWWINDOW | SWP_NOMOVE);
-	win->w = mon->mode.w;
-	win->h = mon->mode.h;
-}
+void RGFW_window_setFullscreenPlatform(RGFW_window* win, RGFW_bool fullscreen) { RGFW_UNUSED(win); RGFW_UNUSED(fullscreen); }
 
 void RGFW_window_maximizePlatform(RGFW_window* win) {
 	RGFW_ASSERT(win != NULL);
@@ -14368,49 +14386,15 @@ void RGFW_window_raise(RGFW_window* win) {
     	objc_msgSend_void_id(win->src.window, sel_registerName("setLevel:"), kCGNormalWindowLevel);
 }
 
-void RGFW_window_setFullscreen(RGFW_window* win, RGFW_bool fullscreen) {
-	RGFW_ASSERT(win != NULL);
-	if (fullscreen && (win->internal.flags & RGFW_windowFullscreen)) return;
-	if (!fullscreen && !(win->internal.flags & RGFW_windowFullscreen)) return;
+void RGFW_window_setFullscreenPlatform(RGFW_window* win, RGFW_bool fullscreen) {
+	if (fullscreen == RGFW_window_isFullscreen(win)) return;
 
 	if (fullscreen) {
-		win->internal.oldX = win->x;
-		win->internal.oldY = win->y;
-		win->internal.oldW = win->w;
-		win->internal.oldH = win->h;
-
-		win->internal.flags |= RGFW_windowFullscreen;
-
-		RGFW_monitor* mon = RGFW_window_getMonitor(win);
-		RGFW_monitor_scaleToWindow(mon, win);
-
-		RGFW_window_setBorder(win, RGFW_FALSE);
-
-		if (mon != NULL) {
-			win->x = mon->x;
-			win->y = mon->y;
-			win->w = mon->mode.w;
-			win->h = mon->mode.h;
-			RGFW_window_resize(win, mon->mode.w, mon->mode.h);
-			RGFW_window_move(win, mon->x, mon->y);
-		}
-
 		((id(*)(id, SEL, SEL))objc_msgSend)((id)win->src.window, sel_registerName("orderFront:"), (SEL)NULL);
 		objc_msgSend_void_id(win->src.window, sel_registerName("setLevel:"), 25);
 	}
 
 	objc_msgSend_void_SEL(win->src.window, sel_registerName("toggleFullScreen:"), NULL);
-
-	if (!fullscreen) {
-		win->x  = win->internal.oldX;
-		win->y  = win->internal.oldY;
-		win->w  = win->internal.oldW;
-		win->h = win->internal.oldH;
-		win->internal.flags &= ~(u32)RGFW_windowFullscreen;
-
-		RGFW_window_resize(win, win->w, win->h);
-		RGFW_window_move(win, win->x, win->y);
-	}
 }
 
 void RGFW_window_maximizePlatform(RGFW_window* win) {
@@ -15995,14 +15979,11 @@ void RGFW_window_maximizePlatform(RGFW_window* win) {
 	RGFW_window_move(win, 0, 0);
 }
 
-void RGFW_window_setFullscreen(RGFW_window* win, RGFW_bool fullscreen) {
-	RGFW_ASSERT(win != NULL);
+void RGFW_window_setFullscreenPlatform(RGFW_window* win, RGFW_bool fullscreen) {
 	if (fullscreen) {
-		win->internal.flags |= RGFW_windowFullscreen;
 		EM_ASM( Module.requestFullscreen(false, true); );
 		return;
 	}
-	win->internal.flags &= ~(u32)RGFW_windowFullscreen;
 	EM_ASM( Module.exitFullscreen(false, true); );
 }
 
@@ -16199,7 +16180,7 @@ typedef void (*RGFW_window_setMaxSize_ptr)(RGFW_window* win, i32 w, i32 h);
 typedef void (*RGFW_window_maximize_ptr)(RGFW_window* win);
 typedef void (*RGFW_window_focus_ptr)(RGFW_window* win);
 typedef void (*RGFW_window_raise_ptr)(RGFW_window* win);
-typedef void (*RGFW_window_setFullscreen_ptr)(RGFW_window* win, RGFW_bool fullscreen);
+typedef void (*RGFW_window_setFullscreenPlatform_ptr)(RGFW_window* win, RGFW_bool fullscreen);
 typedef void (*RGFW_window_setFloating_ptr)(RGFW_window* win, RGFW_bool floating);
 typedef void (*RGFW_window_setOpacity_ptr)(RGFW_window* win, u8 opacity);
 typedef void (*RGFW_window_minimize_ptr)(RGFW_window* win);
@@ -16275,7 +16256,7 @@ typedef struct RGFW_FunctionPointers {
     RGFW_window_maximize_ptr window_maximizePlatform;
     RGFW_window_focus_ptr window_focus;
     RGFW_window_raise_ptr window_raise;
-    RGFW_window_setFullscreen_ptr window_setFullscreen;
+    RGFW_window_setFullscreenPlatform_ptr window_setFullscreenPlatform;
     RGFW_window_setFloating_ptr window_setFloating;
     RGFW_window_setOpacity_ptr window_setOpacity;
     RGFW_window_minimize_ptr window_minimizePlatform;
@@ -16344,7 +16325,7 @@ void RGFW_window_setMaxSize(RGFW_window* win, i32 w, i32 h) { RGFW_api.window_se
 void RGFW_window_maximizePlatform(RGFW_window* win) { RGFW_api.window_maximizePlatform(win); }
 void RGFW_window_focus(RGFW_window* win) { RGFW_api.window_focus(win); }
 void RGFW_window_raise(RGFW_window* win) { RGFW_api.window_raise(win); }
-void RGFW_window_setFullscreen(RGFW_window* win, RGFW_bool fullscreen) { RGFW_api.window_setFullscreen(win, fullscreen); }
+void RGFW_window_setFullscreenPlatform(RGFW_window* win, RGFW_bool fullscreen) { RGFW_api.window_setFullscreenPlatform(win, fullscreen); }
 void RGFW_window_setFloating(RGFW_window* win, RGFW_bool floating) { RGFW_api.window_setFloating(win, floating); }
 void RGFW_window_setOpacity(RGFW_window* win, u8 opacity) { RGFW_api.window_setOpacity(win, opacity); }
 void RGFW_window_minimizePlatform(RGFW_window* win) { RGFW_api.window_minimizePlatform(win); }
@@ -16425,7 +16406,7 @@ void RGFW_load_X11(void) {
     RGFW_api.window_maximizePlatform = RGFW_window_maximizePlatform_X11;
     RGFW_api.window_focus = RGFW_window_focus_X11;
     RGFW_api.window_raise = RGFW_window_raise_X11;
-    RGFW_api.window_setFullscreen = RGFW_window_setFullscreen_X11;
+    RGFW_api.window_setFullscreenPlatform = RGFW_window_setFullscreenPlatform_X11;
     RGFW_api.window_setFloating = RGFW_window_setFloating_X11;
     RGFW_api.window_setOpacity = RGFW_window_setOpacity_X11;
     RGFW_api.window_minimizePlatform = RGFW_window_minimizePlatform_X11;
@@ -16467,7 +16448,7 @@ void RGFW_load_X11(void) {
     RGFW_api.window_maximizePlatform = RGFW_window_maximizePlatform_Wayland;
     RGFW_api.window_focus = RGFW_window_focus_Wayland;
     RGFW_api.window_raise = RGFW_window_raise_Wayland;
-    RGFW_api.window_setFullscreen = RGFW_window_setFullscreen_Wayland;
+    RGFW_api.window_setFullscreenPlatform = RGFW_window_setFullscreenPlatform_Wayland;
     RGFW_api.window_setFloating = RGFW_window_setFloating_Wayland;
     RGFW_api.window_setOpacity = RGFW_window_setOpacity_Wayland;
     RGFW_api.window_minimizePlatform = RGFW_window_minimizePlatform_Wayland;

--- a/RGFW.h
+++ b/RGFW.h
@@ -12577,6 +12577,11 @@ void RGFW_window_resize(RGFW_window* win, i32 w, i32 h) {
 
 	win->w = w;
 	win->h = h;
+	if (win->internal.flags & RGFW_windowNoResize) {
+		win->src.minSizeW = win->src.maxSizeW = w;
+		win->src.minSizeH = win->src.maxSizeH = h;
+	}
+
 	RECT rect = { 0, 0, w, h};
 	DWORD style = RGFW_winapi_window_getStyle(win, win->internal.flags);
 	DWORD exStyle = RGFW_winapi_window_getExStyle(win, win->internal.flags);

--- a/RGFW.h
+++ b/RGFW.h
@@ -5190,7 +5190,6 @@ void RGFW_window_resize(RGFW_window* win, i32 w, i32 h) {
 }
 
 void RGFW_window_setFullscreen(RGFW_window* win, RGFW_fullscreenMode fullscreen) {
-	printf("hello\n");
 	RGFW_ASSERT(win != NULL);
 	if (fullscreen) {
 		win->internal.oldX = win->x;

--- a/RGFW.h
+++ b/RGFW.h
@@ -4088,6 +4088,17 @@ i32 RGFW_init_ptr(const char* className, RGFW_initFlags flags, RGFW_info* info) 
 		}
 	}
 
+	#if (RGFW_PREALLOCATED_MONITORS)
+		_RGFW->monitors.freeList.head = &_RGFW->monitors.data[0];
+		_RGFW->monitors.freeList.cur = _RGFW->monitors.freeList.head;
+
+		for (size_t i = 1; i < RGFW_PREALLOCATED_MONITORS; i++) {
+			RGFW_monitorNode* newNode = &_RGFW->monitors.data[i];
+			_RGFW->monitors.freeList.cur->next = newNode;
+			_RGFW->monitors.freeList.cur = _RGFW->monitors.freeList.cur->next;
+		}
+	#endif
+
     RGFW_initKeycodes();
     i32 out = RGFW_initPlatform(className, flags);
 	if (out != 0) {
@@ -4101,17 +4112,6 @@ i32 RGFW_init_ptr(const char* className, RGFW_initFlags flags, RGFW_info* info) 
 	for (size_t i = 0; i < RGFW_mouseIconCount; i++) {
         _RGFW->standardMice[i] = RGFW_createMouseStandard((RGFW_mouseIcon)i);
 	}
-
-	#if (RGFW_PREALLOCATED_MONITORS)
-		_RGFW->monitors.freeList.head = &_RGFW->monitors.data[0];
-		_RGFW->monitors.freeList.cur = _RGFW->monitors.freeList.head;
-
-		for (size_t i = 1; i < RGFW_PREALLOCATED_MONITORS; i++) {
-			RGFW_monitorNode* newNode = &_RGFW->monitors.data[i];
-			_RGFW->monitors.freeList.cur->next = newNode;
-			_RGFW->monitors.freeList.cur = _RGFW->monitors.freeList.cur->next;
-		}
-	#endif
 
 	RGFW_pollMonitors();
 
@@ -6530,7 +6530,7 @@ void RGFW_unix_parseURI(RGFW_window* win, char* data) {
 	}
 }
 
-#ifndef RGFW_X11
+#if !defined(RGFW_X11) && defined(RGFW_OPENGL)
 RGFW_bool RGFW_loadGL(void) { return RGFW_FALSE; }
 #endif
 

--- a/RGFW.h
+++ b/RGFW.h
@@ -4258,7 +4258,7 @@ RGFW_window* RGFW_createWindowPtr(const char* name, i32 x, i32 y, i32 w, i32 h, 
 		RGFW_window_hide(win);
 	}
 
-	return ret;	RGFW_debugCallback(RGFW_typeInfo, RGFW_infoWindow, "a new window was created");
+	RGFW_debugCallback(RGFW_typeInfo, RGFW_infoWindow, "a new window was created");
 
 	return ret;
 }
@@ -5191,6 +5191,12 @@ void RGFW_window_resize(RGFW_window* win, i32 w, i32 h) {
 
 void RGFW_window_setFullscreen(RGFW_window* win, RGFW_fullscreenMode fullscreen) {
 	RGFW_ASSERT(win != NULL);
+	if ((fullscreen == RGFW_fullscreenExclusive && (win->internal.flags & RGFW_windowFullscreenExclusive)) || 
+		(fullscreen == RGFW_fullscreenBorderless && RGFW_BOOL(win->internal.flags & RGFW_windowFullscreenBorderless)) ||
+		fullscreen == 0 && RGFW_window_isFullscreen(win) == RGFW_FALSE) {
+			return;
+	}
+
 	if (fullscreen) {
 		win->internal.oldX = win->x;
 		win->internal.oldY = win->y;
@@ -14391,8 +14397,6 @@ void RGFW_window_raise(RGFW_window* win) {
 }
 
 void RGFW_window_setFullscreenPlatform(RGFW_window* win, RGFW_bool fullscreen) {
-	if (fullscreen == RGFW_window_isFullscreen(win)) return;
-
 	if (fullscreen) {
 		((id(*)(id, SEL, SEL))objc_msgSend)((id)win->src.window, sel_registerName("orderFront:"), (SEL)NULL);
 		objc_msgSend_void_id(win->src.window, sel_registerName("setLevel:"), 25);

--- a/examples/gears/gears.c
+++ b/examples/gears/gears.c
@@ -25,6 +25,10 @@
  * See usage() below for command line options.
  */
 
+#ifdef _MSC_VER
+	#pragma comment(lib, "opengl32")
+#endif
+
 #define RGFW_DEBUG
 #define GL_SILENCE_DEPRECATION
 #define RGFW_OPENGL
@@ -435,7 +439,7 @@ main(int argc, char *argv[])
    }
 
    if(fullscreen){
-	   flag = RGFW_windowFullscreen;
+	   flag = RGFW_windowFullscreenBorderless;
    }
 
    win = RGFW_createWindow("gears", x, y, winWidth, winHeight, RGFW_windowCenter | RGFW_windowOpenGL | flag);

--- a/examples/srgb/srgb.c
+++ b/examples/srgb/srgb.c
@@ -4,6 +4,10 @@
 #define RGFW_IMPLEMENTATION
 #include "RGFW.h"
 
+#ifdef _MSC_VER
+	#pragma comment(lib, "opengl32")
+#endif
+
 #ifdef RGFW_MACOS
 #include <OpenGL/gl.h>
 #else


### PR DESCRIPTION
- create enum `RGFW_fullscreenMode` for no fullscreen, exclusive fullscreen or borderless fullscreen modes and comments direclty defining what these modes mean for the user
- allow the user to set the fullscreen mode using `RGFW_window_setFullscreen`
- use `RGFW_window_setFullscreen` as a standard function in RGFW, to standardize fullscreen behavior across each platform, using `RGFW_window_setFullscreenPlatform` for platform specific code
- save the fullscreen monitor to avoid bugs
- save the border state so that way the window returns to the original border state rather than possibly creating a bug if the window was borderless to begin with 